### PR TITLE
feat: add callback argument to consent method

### DIFF
--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -55,15 +55,6 @@ export default class Playback extends UIObject {
   }
 
   /**
-   * Determine if the playback has user consent.
-   * @property consented
-   * @type Boolean
-   */
-  get consented() {
-    return this._consented
-  }
-
-  /**
    * @method constructor
    * @param {Object} options the options object
    * @param {Strings} i18n the internationalization component
@@ -79,9 +70,11 @@ export default class Playback extends UIObject {
   /**
    * Gives user consent to playback (mobile devices).
    * @method consent
+   * @param {Function} callback function called when playback is consented
    */
-  consent() {
-    this._consented = true
+  consent(cb) {
+    if (typeof cb === 'function')
+      cb()
   }
 
   /**

--- a/src/base/playback.test.js
+++ b/src/base/playback.test.js
@@ -27,10 +27,12 @@ describe('Playback', function() {
     expect(this.basePlayback.isHighDefinitionInUse()).to.be.equal(false)
   })
 
-  it('can be consented', () => {
-    expect(this.basePlayback.consented).to.be.equal(false)
-    this.basePlayback.consent()
-    expect(this.basePlayback.consented).to.be.equal(true)
+  it('can be consented', (done) => {
+    const callback = sinon.spy(() => {
+      callback.should.have.been.calledOnce
+      done()
+    })
+    this.basePlayback.consent(callback)
   })
 
   it('destroys by removing element from DOM', () => {

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -437,11 +437,14 @@ export default class Player extends BaseObject {
   /**
    * Gives user consent to playback. Required by mobile device after a click event before Player.load().
    * @method consent
-   * @return {Player} itself
+   * @param {Function} callback function called when current playback is consented
+   * @example
+   * ```javascript
+   * player.consent(function() { doSomethingNext(); });
+   * ```
    */
-  consent() {
-    this.core.getCurrentPlayback().consent()
-    return this
+  consent(cb) {
+    this.core.getCurrentPlayback().consent(cb)
   }
 
   /**

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -251,9 +251,18 @@ export default class HTML5Video extends Playback {
 
   // On mobile device, HTML5 video element "retains" user action consent if
   // load() method is called. See Player.consent().
-  consent() {
-    if (!this.isPlaying()) {
-      super.consent()
+  consent(cb) {
+    if (this.isPlaying()) {
+      super.consent(cb)
+    } else {
+      let eventHandler = () => {
+        this.el.removeEventListener('loadedmetadata', eventHandler, false)
+        this.el.removeEventListener('error', eventHandler, false)
+        super.consent(cb)
+      }
+
+      this.el.addEventListener('loadedmetadata', eventHandler, false)
+      this.el.addEventListener('error', eventHandler, false)
       this.el.load()
     }
   }

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -88,12 +88,15 @@ describe('HTML5Video playback', function() {
     })
   })
 
-  it('can be consented', function() {
-    const playback = new HTML5Video({ src: 'http://example.com/dash.ogg', mute: true })
+  it('can be consented', function(done) {
+    this.timeout(5000)
+    const playback = new HTML5Video({ src: '/test/fixtures/SampleVideo_360x240_1mb.mp4' })
+    const callback = sinon.spy(() => {
+      callback.should.have.been.calledOnce
+      done()
+    })
 
-    expect(playback.consented).to.be.false
-    playback.consent()
-    expect(playback.consented).to.be.true
+    playback.consent(callback)
   })
 
   it('isPlaying() is true after constructor when autoPlay is true', function(done) {


### PR DESCRIPTION
Fix an implementation issue with the `consent()` method which is asynchronous.
It add a callback argument to prevents the use of timeout or process next tick trick.

```javascript
player.consent(() => {
  // do something next...
})
```
