### PR TITLE
feat(utils): enchance dom recycler

### DIFF
--- a/src/base/ui_object.js
+++ b/src/base/ui_object.js
@@ -193,7 +193,7 @@ export default class UIObject extends BaseObject {
       const attrs = $.extend({}, this.attributes)
       if (this.id) attrs.id = this.id
       if (this.className) attrs['class'] = this.className
-      const $el = DomRecycler.create(this.tagName).attr(attrs)
+      const $el = $(DomRecycler.create(this.tagName)).attr(attrs)
       this.setElement($el, false)
     } else { this.setElement(this.el, false) }
 

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -127,10 +127,12 @@ export default class HTML5Video extends Playback {
       loop: this.options.loop,
       poster: posterUrl,
       preload: preload || 'metadata',
-      controls: (playbackConfig.controls || this.options.useVideoTagDefaultControls) && 'controls',
       crossOrigin: playbackConfig.crossOrigin,
       'x-webkit-playsinline': playbackConfig.playInline
     })
+
+    if (playbackConfig.controls || this.options.useVideoTagDefaultControls)
+      this.$el.attr('controls', '')
 
     playbackConfig.playInline && (this.$el.attr({ playsinline: 'playsinline' }))
     playbackConfig.crossOrigin && (this.$el.attr({ crossorigin: playbackConfig.crossOrigin }))

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -452,7 +452,7 @@ export default class HTML5Video extends Playback {
     this.el.removeAttribute('src')
     this.el.load() // load with no src to stop loading of the previous source and avoid leaks
     this._src = null
-    DomRecycler.garbage(this.$el)
+    DomRecycler.garbage(this.el)
   }
 
   seek(time) {

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -125,9 +125,17 @@ describe('HTML5Video playback', function() {
   })
 
   it('allows displaying default video tag controls', function() {
-    const options = $.extend({ playback: { controls: 'controls' } }, this.options)
-    const playback = new HTML5Video(options)
-    expect(playback.el.controls).to.be.true
+    const options1 = Object.assign({}, this.options)
+    const playback1 = new HTML5Video(options1)
+    expect(playback1.el.hasAttribute('controls')).to.be.false
+
+    const options2 = Object.assign({ playback: { controls: 'controls' } }, this.options)
+    const playback2 = new HTML5Video(options2)
+    expect(playback2.el.hasAttribute('controls')).to.be.true
+
+    const options3 = Object.assign({ playback: { controls: false } }, this.options)
+    const playback3 = new HTML5Video(options3)
+    expect(playback3.el.hasAttribute('controls')).to.be.false
   })
 
   it('mute or unmute video element when volume is changed', function() {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -285,7 +285,7 @@ export function canAutoPlayMedia(cb, options) {
   }
 }
 
-// Simple Zepto element factory with video recycle feature.
+// Simple element factory with video recycle feature.
 const videoStack = []
 
 export class DomRecycler {
@@ -297,14 +297,14 @@ export class DomRecycler {
     if (this.options.recycleVideo && name === 'video' && videoStack.length > 0)
       return videoStack.shift()
 
-    return $('<' + name + '>')
+    return document.createElement(name)
   }
 
-  static garbage($el) {
-    // Expect Zepto collection with single element (does not iterate!)
-    if (!this.options.recycleVideo || $el[0].tagName.toUpperCase() !== 'VIDEO') return
-    $el.children().remove()
-    videoStack.push($el)
+  static garbage(el) {
+    if (!this.options.recycleVideo || el.tagName.toUpperCase() !== 'VIDEO') return
+    $(el).children().remove()
+    Object.values(el.attributes).forEach(attr => el.removeAttribute(attr.name))
+    videoStack.push(el)
   }
 }
 

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,5 +1,4 @@
 import * as utils from './utils'
-import  $ from 'clappr-zepto'
 
 const pushUrl = function(path) {
   window.history.pushState({},'', path)
@@ -245,17 +244,16 @@ describe('Utils', function() {
       expect(utils.DomRecycler.options.recycleVideo).to.be.false
     })
 
-    it('create a Zepto collection object', function() {
-      const $el = utils.DomRecycler.create('div')
-      // Zepto collection assertion : https://github.com/madrobby/zepto/issues/349#issuecomment-4985091
-      expect($.zepto.isZ($el)).to.be.true
+    it('create a dom element', function() {
+      const el = utils.DomRecycler.create('div')
+      expect(el.tagName).to.equal('DIV')
     })
 
     it('does not recycle video tag by default', function() {
       const video1 = utils.DomRecycler.create('video')
       utils.DomRecycler.garbage(video1)
       const video2 = utils.DomRecycler.create('video')
-      expect(video1[0]).to.not.be.equal(video2[0])
+      expect(video1).to.not.be.equal(video2)
     })
 
     it('recycle video tag if recycleVideo option is set', function() {
@@ -263,7 +261,7 @@ describe('Utils', function() {
       const video1 = utils.DomRecycler.create('video')
       utils.DomRecycler.garbage(video1)
       const video2 = utils.DomRecycler.create('video')
-      expect(video1[0]).to.be.equal(video2[0])
+      expect(video1).to.be.equal(video2)
     })
   })
 


### PR DESCRIPTION
It now stack and create DOM (video) elements instead of Zepto collection.

It perform a better cleanup by removing all atributes (required when using recycleVideo playback option without core-plugins)

It also fix a minor issue by properly add or remove the `controls` attribute if you set playback controls option to "any value" or false. By default, it does not add attribute if playback `controls` option not set.

Note: the video element `controls` attribute is not a boolean, the native controls are displayed if the attribute is added (value is ignored) and native controls are hidden if the attribute is missing.
