### PR TITLE
Feature - Add minimum DVR support to HTML5Video Playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ playback: {
   controls: true,
   crossOrigin: 'use-credentials',
   playInline: true,
+  minimumDvrSize: null,
   externalTracks: [],
   hlsjsConfig: {},
   shakaConfiguration: {},
@@ -360,6 +361,9 @@ See more about the video tag crossOrigin attribute [here](https://developer.mozi
 > Default value: `true`
 
 Enable or Disable the [HTML5 video tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video) playInline attribute.
+
+#### minimumDvrSize
+Use to set the minimum value to active DVR for live media. This option is only used for HTML5Playback at this moment.
 
 #### externalTracks
 An array of tracks. Each track must have the attributes `src`, `lang` and `label`. The attribute `kind` on track object is optional because of the default value `subtitles`.

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -469,6 +469,11 @@ export default class HTML5Video extends Playback {
     DomRecycler.garbage(this.el)
   }
 
+  _updateDvr(status) {
+    this.trigger(Events.PLAYBACK_DVR, status)
+    this.trigger(Events.PLAYBACK_STATS_ADD, { 'dvr': status })
+  }
+
   seek(time) {
     this.el.currentTime = time
   }

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -296,6 +296,7 @@ export default class HTML5Video extends Playback {
 
   pause() {
     this.el.pause()
+    this.dvrEnabled && this._updateDvr(true)
   }
 
   stop() {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -487,6 +487,10 @@ export default class HTML5Video extends Playback {
       Log.warn('Attempt to seek to a negative time. Resetting to live point. Use seekToLivePoint() to seek to the live point.')
       time = this.getDuration()
     }
+    // assume live if time within 3 seconds of end of stream
+    this.dvrEnabled && this._updateDvr(time < this.getDuration()-3)
+    time += this.el.seekable.start(0)
+
     this.el.currentTime = time
   }
 

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -483,6 +483,10 @@ export default class HTML5Video extends Playback {
   }
 
   seek(time) {
+    if (time < 0) {
+      Log.warn('Attempt to seek to a negative time. Resetting to live point. Use seekToLivePoint() to seek to the live point.')
+      time = this.getDuration()
+    }
     this.el.currentTime = time
   }
 

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -95,6 +95,10 @@ export default class HTML5Video extends Playback {
     return this._isBuffering
   }
 
+  get dvrEnabled() {
+    return this.getDuration() >= this._minDvrSize && this.isLive
+  }
+
   get hasMinimumDVRConfig() {
     return this.options.playback && this.options.playback.minimumDvrSize && typeof (this.options.playback.minimumDvrSize) !== 'undefined'
   }

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -95,6 +95,10 @@ export default class HTML5Video extends Playback {
     return this._isBuffering
   }
 
+  get hasMinimumDVRConfig() {
+    return this.options.playback && this.options.playback.minimumDvrSize && typeof (this.options.playback.minimumDvrSize) !== 'undefined'
+  }
+
   constructor(...args) {
     super(...args)
     this._destroyed = false
@@ -108,6 +112,7 @@ export default class HTML5Video extends Playback {
     // backwards compatibility (TODO: remove on 0.3.0)
     this.options.playback || (this.options.playback = this.options || {})
     this.options.playback.disableContextMenu = this.options.playback.disableContextMenu || this.options.disableVideoTagContextMenu
+    this._minDvrSize = this.hasMinimumDVRConfig ? this.options.playback.minimumDvrSize : 60
 
     const playbackConfig = this.options.playback
     const preload = playbackConfig.preload || (Browser.isSafari ? 'auto' : this.options.preload)

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -496,11 +496,8 @@ export default class HTML5Video extends Playback {
   }
 
   _onTimeUpdate() {
-    if (this.getPlaybackType() === Playback.LIVE)
-      this.trigger(Events.PLAYBACK_TIMEUPDATE, { current: 1, total: 1 }, this.name)
-    else
-      this.trigger(Events.PLAYBACK_TIMEUPDATE, { current: this.el.currentTime, total: this.el.duration }, this.name)
-
+    const duration = this.isLive ? this.getDuration() : this.el.duration
+    this.trigger(Events.PLAYBACK_TIMEUPDATE, { current: this.el.currentTime, total: duration }, this.name)
   }
 
   _onProgress() {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -103,8 +103,12 @@ export default class HTML5Video extends Playback {
     return this.getDuration() >= this._minDvrSize && this.isLive
   }
 
-  get hasMinimumDVRConfig() {
-    return this.options.playback && this.options.playback.minimumDvrSize && typeof (this.options.playback.minimumDvrSize) !== 'undefined'
+  get minimumDVRSizeConfig() {
+    return this.options.playback && this.options.playback.minimumDvrSize
+  }
+
+  get isValidMinimumDVRSizeConfig() {
+    return typeof (this.minimumDVRSizeConfig) !== 'undefined' && typeof (this.minimumDVRSizeConfig) === 'number'
   }
 
   constructor(...args) {
@@ -120,7 +124,8 @@ export default class HTML5Video extends Playback {
     // backwards compatibility (TODO: remove on 0.3.0)
     this.options.playback || (this.options.playback = this.options || {})
     this.options.playback.disableContextMenu = this.options.playback.disableContextMenu || this.options.disableVideoTagContextMenu
-    this._minDvrSize = this.hasMinimumDVRConfig ? this.options.playback.minimumDvrSize : 60
+    debugger
+    this._minDvrSize = this.isValidMinimumDVRSizeConfig ? this.minimumDVRSizeConfig : 60
 
     const playbackConfig = this.options.playback
     const preload = playbackConfig.preload || (Browser.isSafari ? 'auto' : this.options.preload)

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -485,6 +485,13 @@ export default class HTML5Video extends Playback {
   }
 
   getDuration() {
+    if (this.isLive) {
+      try {
+        return this.el.seekable.end(0) - this.el.seekable.start(0)
+      } catch (e) {
+        setTimeout(() => this._updateSettings(), 1000)
+      }
+    }
     return this.el.duration
   }
 

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -124,7 +124,6 @@ export default class HTML5Video extends Playback {
     // backwards compatibility (TODO: remove on 0.3.0)
     this.options.playback || (this.options.playback = this.options || {})
     this.options.playback.disableContextMenu = this.options.playback.disableContextMenu || this.options.disableVideoTagContextMenu
-    debugger
     this._minDvrSize = this.isValidMinimumDVRSizeConfig ? this.minimumDVRSizeConfig : 60
 
     const playbackConfig = this.options.playback

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -95,6 +95,10 @@ export default class HTML5Video extends Playback {
     return this._isBuffering
   }
 
+  get isLive() {
+    return this.getPlaybackType() === Playback.LIVE
+  }
+
   get dvrEnabled() {
     return this.getDuration() >= this._minDvrSize && this.isLive
   }

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -550,4 +550,15 @@ describe('HTML5Video playback', function() {
 
     expect(html5Video.dvrEnabled).toEqual(true)
   })
+
+  describe('seek', () => {
+    test('use duration when occurs seek with negative values', () => {
+      const html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8' })
+      jest.spyOn(html5Video, 'getDuration').mockReturnValue(5000)
+      html5Video.seek(-1)
+
+      expect(html5Video.el.currentTime).toEqual(5000)
+    })
+
+  })
 })

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -315,6 +315,17 @@ describe('HTML5Video playback', function() {
       expect(html5Video.options.playback.somePlaybackOption).toBeTruthy()
       expect(html5Video.options.playback.nonPlaybackOption).toBeFalsy()
     })
+
+    it('respect minimumDvrSize precedence over _minDvrSize default value', () => {
+      const options = { src: 'http://example.com/video.m3u8' }
+      let html5Video = new HTML5Video(options)
+
+      expect(html5Video._minDvrSize).toEqual(60)
+
+      html5Video = new HTML5Video({ ...options, playback: { minimumDvrSize: 10 } })
+
+      expect(html5Video._minDvrSize).toEqual(10)
+    })
   })
 
   describe('video element', () => {

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -538,4 +538,16 @@ describe('HTML5Video playback', function() {
     expect(callback1).toHaveBeenCalledWith(DVR_STATUS)
     expect(callback2).toHaveBeenCalledWith({ dvr: DVR_STATUS })
   })
+
+  test('dvrEnabled getter return current DVR status', () => {
+    const html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8' })
+    jest.spyOn(html5Video, 'dvrEnabled', 'get')
+
+    expect(html5Video.dvrEnabled).toEqual(false)
+
+    jest.spyOn(html5Video, 'getDuration').mockReturnValue(5000)
+    jest.spyOn(html5Video, 'getPlaybackType').mockReturnValue('live')
+
+    expect(html5Video.dvrEnabled).toEqual(true)
+  })
 })

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -523,4 +523,19 @@ describe('HTML5Video playback', function() {
       expect(callback).toHaveBeenCalledWith({ current: undefined, total: 50 }, 'html5_video')
     })
   })
+
+  test('_updateDvr triggers DVR events with current status', () => {
+    const DVR_STATUS = 'enabled'
+    const callback1 = jest.fn()
+    const callback2 = jest.fn()
+    const html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8' })
+
+    html5Video.on(Events.PLAYBACK_DVR, callback1)
+    html5Video.on(Events.PLAYBACK_STATS_ADD, callback2)
+
+    html5Video._updateDvr(DVR_STATUS)
+
+    expect(callback1).toHaveBeenCalledWith(DVR_STATUS)
+    expect(callback2).toHaveBeenCalledWith({ dvr: DVR_STATUS })
+  })
 })

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -553,6 +553,26 @@ describe('HTML5Video playback', function() {
     expect(html5Video.dvrEnabled).toEqual(true)
   })
 
+  test('isValidMinimumDVRSizeConfig getter guarantee a valid minimum DVR size', () => {
+    let html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8' })
+    expect(html5Video.isValidMinimumDVRSizeConfig).toBeFalsy()
+
+    html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8', playback: { minimumDvrSize: null } })
+    expect(html5Video.isValidMinimumDVRSizeConfig).toBeFalsy()
+
+    html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8', playback: { minimumDvrSize: 'test' } })
+    expect(html5Video.isValidMinimumDVRSizeConfig).toBeFalsy()
+
+    html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8', playback: { minimumDvrSize: '10' } })
+    expect(html5Video.isValidMinimumDVRSizeConfig).toBeFalsy()
+
+    html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8', playback: { minimumDvrSize: 0 } })
+    expect(html5Video.isValidMinimumDVRSizeConfig).toBeTruthy()
+
+    html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8', playback: { minimumDvrSize: 10 } })
+    expect(html5Video.isValidMinimumDVRSizeConfig).toBeTruthy()
+  })
+
   describe('seek', () => {
     test('use duration when occurs seek with negative values', () => {
       const html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8' })

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -560,5 +560,29 @@ describe('HTML5Video playback', function() {
       expect(html5Video.el.currentTime).toEqual(5000)
     })
 
+    test('always use a margin for video currentTime to check DVR status', () => {
+      const start = [0]
+      const end = [100]
+
+      const html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8' })
+      jest.spyOn(html5Video, 'getPlaybackType').mockReturnValue('live')
+      jest.spyOn(html5Video, '_updateDvr')
+      html5Video.setElement({
+        get seekable() {
+          return {
+            start: (i) => start[i],
+            end: (i) => end[i],
+            get length() { return start.length }
+          }
+        }
+      })
+      html5Video.seek(html5Video.el.seekable.end(0))
+
+      expect(html5Video._updateDvr).toHaveBeenCalledWith(false)
+
+      html5Video.seek(96)
+
+      expect(html5Video._updateDvr).toHaveBeenCalledWith(true)
+    })
   })
 })

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -466,4 +466,50 @@ describe('HTML5Video playback', function() {
       expect(html5Video.getDuration).toHaveReturnedWith(20)
     })
   })
+
+  describe('_onTimeUpdate', () => {
+    test('return el.duration for VoD on PLAYBACK_TIMEUPDATE event', () => {
+      const callback = jest.fn()
+      const html5Video = new HTML5Video({ src: 'http://example.com/video.mp4' })
+      html5Video.setElement({
+        get duration() { return 10 },
+        get seekable() {
+          return {
+            start: (i) => start[i],
+            end: (i) => end[i],
+            get length() { return start.length }
+          }
+        }
+      })
+      html5Video.on(Events.PLAYBACK_TIMEUPDATE, callback)
+      html5Video._onTimeUpdate()
+
+      expect(callback).toHaveBeenCalledWith({ current: undefined, total: 10 }, 'html5_video')
+    })
+
+    test('return getDuration() for Live on PLAYBACK_TIMEUPDATE event', () => {
+      let start = [0]
+      let end = [50]
+      const callback = jest.fn()
+      const html5Video = new HTML5Video({ src: 'http://example.com/video.m3u8' })
+
+      html5Video.setElement({
+        get duration() { return 10 },
+        get seekable() {
+          return {
+            start: (i) => start[i],
+            end: (i) => end[i],
+            get length() { return start.length }
+          }
+        }
+      })
+
+      jest.spyOn(html5Video, 'getPlaybackType').mockReturnValue('live')
+
+      html5Video.on(Events.PLAYBACK_TIMEUPDATE, callback)
+      html5Video._onTimeUpdate()
+
+      expect(callback).toHaveBeenCalledWith({ current: undefined, total: 50 }, 'html5_video')
+    })
+  })
 })

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -484,6 +484,7 @@ describe('HTML5Video playback', function() {
       const html5Video = new HTML5Video({ src: 'http://example.com/video.mp4' })
       html5Video.setElement({
         get duration() { return 10 },
+        /* eslint-disable */
         get seekable() {
           return {
             start: (i) => start[i],
@@ -491,6 +492,7 @@ describe('HTML5Video playback', function() {
             get length() { return start.length }
           }
         }
+        /* eslint-disable */
       })
       html5Video.on(Events.PLAYBACK_TIMEUPDATE, callback)
       html5Video._onTimeUpdate()


### PR DESCRIPTION
## Summary

This PR adds a minimum DVR support to HTML5Playback. With this PR, Clappr now supports play live streams with DVR on iOS devices. This new implementation adds the necessity to revisit all external playbacks to unify the DVR support and configuration but this refactor needs to be in another PR for priority purposes.

## Changes

* Create new option `playback.minimumDvrSize`;
  * Option to define the minimum DVR size to active seek on Clappr live mode.
* Create new internal reference `_minDvrSize`;
  * Playback internal reference for the option `playback.minimumDvrSize`.
  * If the option `minimumDvrSize` is not defined, the default value is **60 seconds**.
* Refactor `getDuration` method;
  * Add new logic to get duration for live media.
* Create new getter `dvrEnabled`;
  * This getter checks:
    * If the playback type is`live`;
    *  If the duration of the live media is greater than `_minDvrSize`;
* Create new internal method `_updateDvr`;
  * Triggers `PLAYBACK_DVR ` and `PLAYBACK_STATS_ADD` events.
* Refactor `pause` method;
  * Triggers `_updateDvr` if getter `dvrEnabled` returns `true`.
* Update `seek` method;
  * Handle seeks to negative values.
  * Triggers `_updateDvr` if getter `dvrEnabled` returns `true`.
* Refactor `_onTimeUpdate` internal method;
  * Remove fixed value sent on `PLAYBACK_TIMEUPDATE` event for live media.
  * Send correct `currentTime` and `duration` for live and VoD media.

## How to test

* Run Clappr locally with live media configured;
  * Remember to use one live media with DVR.
* Use the [MediaControl](https://github.com/clappr/clappr-plugins/blob/master/src/plugins/media_control/media_control.js) and  the [DVRControls](https://github.com/clappr/clappr-plugins/blob/master/src/plugins/dvr_controls/dvr_controls.js) plugins;
  * Add `clappr-plugins` JSDelivr on `/public/index.html`
    *  JSDelivr script: `<script type="text/javascript" charset="utf-8" src="https://cdn.jsdelivr.net/npm/@clappr/plugins@latest/dist/clappr-plugins.min.js"></script>`
  * Add `plugins: [ClapprPlugins.MediaControl, ClapprPlugins.DVRControls]` on `/public/j/clappr-config.js` initial options
*  Open local page test on Safari browser;
* The Safari will use the HTM5Playback;
  * The DVR will be active and other plugins that interact with DVR too (seekbar, back to live button and etc)