### PR TITLE
Tests - Increase test coverage for existent Utils modules

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -8,6 +8,19 @@ import Media from '../base/media'
 import Browser from '../components/browser'
 import $ from 'clappr-zepto'
 
+const idsCounter = {}
+const videoStack = []
+
+export const requestAnimationFrame = (window.requestAnimationFrame ||
+  window.mozRequestAnimationFrame ||
+  window.webkitRequestAnimationFrame ||
+  function(fn) { window.setTimeout(fn, 1000/60) }).bind(window)
+
+export const cancelAnimationFrame = (window.cancelAnimationFrame ||
+ window.mozCancelAnimationFrame ||
+ window.webkitCancelAnimationFrame ||
+ window.clearTimeout).bind(window)
+
 export function assign(obj, source) {
   if (source) {
     for (const prop in source) {
@@ -32,8 +45,7 @@ export function extend(parent, properties) {
 }
 
 export function formatTime(time, paddedHours) {
-  if (!isFinite(time))
-    return '--:--'
+  if (!isFinite(time)) return '--:--'
 
   time = time * 1000
   time = parseInt(time/1000)
@@ -191,8 +203,6 @@ export function seekStringToSeconds(paramName = 't') {
   return seconds
 }
 
-const idsCounter = {}
-
 export function uniqueId(prefix) {
   idsCounter[prefix] || (idsCounter[prefix] = 0)
   const id = ++idsCounter[prefix]
@@ -207,16 +217,6 @@ export function currentScriptUrl() {
   const scripts = document.getElementsByTagName('script')
   return scripts.length ? scripts[scripts.length - 1].src : ''
 }
-
-export const requestAnimationFrame = (window.requestAnimationFrame ||
-                            window.mozRequestAnimationFrame ||
-                            window.webkitRequestAnimationFrame ||
-                            function(fn) { window.setTimeout(fn, 1000/60) }).bind(window)
-
-export const cancelAnimationFrame = (window.cancelAnimationFrame ||
-                           window.mozCancelAnimationFrame ||
-                           window.webkitCancelAnimationFrame ||
-                           window.clearTimeout).bind(window)
 
 export function getBrowserLanguage() {
   return window.navigator && window.navigator.language
@@ -286,8 +286,6 @@ export function canAutoPlayMedia(cb, options) {
 }
 
 // Simple element factory with video recycle feature.
-const videoStack = []
-
 export class DomRecycler {
   static configure(options) {
     this.options = $.extend(this.options, options)

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,11 +1,32 @@
 import * as utils from './utils'
 
-const pushUrl = function(path) {
+const pushUrl = (path) => {
   window.history.pushState({},'', path)
 }
 
-describe('Utils', function() {
-  describe('extend', function() {
+describe('Utils', () => {
+  describe('assign module', () => {
+    test('Returns same first object for calls without two objects', () => {
+      const obj = { string: 'test', number: 1 }
+
+      expect(utils.assign(obj)).toEqual({ string: 'test', number: 1 })
+    })
+
+    test('Returns same first object for calls with empty second object', () => {
+      const obj = { string: 'test', number: 1 }
+
+      expect(utils.assign(obj, {})).toEqual({ string: 'test', number: 1 })
+    })
+
+    test('Returns the merge result of the two received objects', () => {
+      const obj1 = { string: 'test', number: 1 }
+      const obj2 = { boolean: true }
+
+      expect(utils.assign(obj1, obj2)).toEqual({ boolean: true, string: 'test', number: 1 })
+    })
+  })
+
+  describe('extend module', () => {
     class Base {
       get name() { return 'base' }
       constructor(p1, p2) {
@@ -15,21 +36,21 @@ describe('Utils', function() {
       test() {}
     }
 
-    test('should create a new class that extends parent', function() {
+    test('should create a new class that extends parent', () => {
       const Derived = utils.extend(Base, {})
       const d = new Derived(1, 'some-value')
       expect(d.name).toEqual('base')
       expect(d.test()).toBeUndefined()
     })
 
-    test('should pass constructor parameters to super constructor', function() {
+    test('should pass constructor parameters to super constructor', () => {
       const Derived = utils.extend(Base, {})
       const d = new Derived(1, 'some-value')
       expect(d.prop1).toEqual(1)
       expect(d.prop2).toEqual('some-value')
     })
 
-    test('should pass constructor parameters to initialize method', function() {
+    test('should pass constructor parameters to initialize method', () => {
       const Derived = utils.extend(Base, {
         initialize(p1, p2, p3) {
           this.prop3 = p3
@@ -39,7 +60,7 @@ describe('Utils', function() {
       expect(d.prop3).toEqual(42)
     })
 
-    it ('should support overriding methods', function() {
+    it ('should support overriding methods', () => {
       const Derived = utils.extend(Base, {
         test() { return true }
       })
@@ -47,7 +68,7 @@ describe('Utils', function() {
       expect(d.test()).toBeTruthy()
     })
 
-    it ('should support overriding read-only properties', function() {
+    it ('should support overriding read-only properties', () => {
       const Derived = utils.extend(Base, {
         get name() { return 'derived' }
       })
@@ -56,20 +77,83 @@ describe('Utils', function() {
     })
   })
 
-  test('creates unique id for a given prefix', function() {
-    expect(utils.uniqueId('a')).not.toEqual(utils.uniqueId('a'))
+  describe('formatTime module', () => {
+    test('converts seconds to time string format', () => {
+      expect(utils.formatTime(1)).toEqual('00:01')
+      expect(utils.formatTime(10)).toEqual('00:10')
+      expect(utils.formatTime(60 * 10 + 15)).toEqual('10:15')
+      expect(utils.formatTime(60 * 60 * 12)).toEqual('12:00:00')
+      expect(utils.formatTime(60 * 60 * 24)).toEqual('1:00:00:00')
+      expect(utils.formatTime(60 * 60 * 27)).toEqual('1:03:00:00')
+      expect(utils.formatTime(1000/0)).toEqual('--:--')
+    })
   })
 
-  test('converts seconds to time string format', function() {
-    expect(utils.formatTime(1)).toEqual('00:01')
-    expect(utils.formatTime(10)).toEqual('00:10')
-    expect(utils.formatTime(60 * 10 + 15)).toEqual('10:15')
-    expect(utils.formatTime(60 * 60 * 12)).toEqual('12:00:00')
-    expect(utils.formatTime(60 * 60 * 24)).toEqual('1:00:00:00')
-    expect(utils.formatTime(60 * 60 * 27)).toEqual('1:03:00:00')
+  describe('Fullscreen module', () => {
+    test('Returns the current fullscreen element', () => {
+
+    })
+    test('Requests fullscreen for one element', () => {
+
+    })
+    test('Cancel fullscreen', () => {
+
+    })
+    test('Check if fullscreen is enabled', () => {
+
+    })
   })
 
-  test('should convert querystring seek regex in seconds', function() {
+  describe('Config module', () => {
+    beforeEach(() => {
+      localStorage.removeItem('clappr.localhost.volume')
+    })
+
+    test('restores default volume', () => {
+      expect(utils.Config.restore('volume')).toEqual(100)
+    })
+
+    test('restores a persisted volume', () => {
+      utils.Config.persist('volume', 42)
+      expect(utils.Config.restore('volume')).toEqual(42)
+    })
+
+    test('returns undefined for unknown key', () => {
+      expect(utils.Config.restore('unknown.key.CAFE')).toEqual(undefined)
+    })
+
+    test('don\'t persist invalid keys', () => {
+      jest.spyOn(utils.Config, '_createKeyspace').mockImplementation(1)
+      expect(utils.Config.persist()).toBeFalsy()
+    })
+  })
+
+  describe('QueryString module', () => {
+    beforeEach(() => {
+      window.history.pushState({}, '', `${window.location.href}?query_string=test&another_query_string=0`)
+    })
+    afterEach(() => {
+      window.history.pushState({}, '', window.location.href)
+    })
+
+    test('Creates a dict with each query string in the URL', () => {
+      const test = window.location.search.substring(1)
+      const parsedQueryStrings = utils.QueryString.parse(test)
+
+      expect(parsedQueryStrings).toEqual({ 'query_string': 'test', 'another_query_string': '0' })
+    })
+
+    test('Returns current query strings on the URL', () => {
+      expect(utils.QueryString.params).toEqual({ 'query_string': 'test', 'another_query_string': '0' })
+    })
+
+    test('Returns current hash strings on the URL', () => {
+      window.history.pushState({}, '', `${window.location.href}#hash_string=test`)
+      expect(utils.QueryString.hashParams).toEqual({ 'hash_string': 'test' })
+    })
+  })
+
+  test('seekStringToSeconds module should convert seek regex in seconds', () => {
 
     pushUrl('/some/path/?t=1h10m30s')
     expect(utils.seekStringToSeconds()).toEqual(4230)
@@ -147,23 +231,68 @@ describe('Utils', function() {
     expect(utils.seekStringToSeconds()).toEqual(0)
   })
 
-  describe('removeArrayItem', function() {
-    test('removes an item when it exists', function() {
+  test('creates unique id for a given prefix', () => {
+    expect(utils.uniqueId('a')).not.toEqual(utils.uniqueId('a'))
+  })
+
+  test('isNumber module checks if one data is a valid number', () => {
+    expect(utils.isNumber(1)).toBeTruthy()
+    expect(utils.isNumber('1')).toBeTruthy()
+    expect(utils.isNumber('number')).toBeFalsy()
+    expect(utils.isNumber(true)).toBeFalsy()
+    expect(utils.isNumber(() => '')).toBeFalsy()
+  })
+
+  test('currentScriptUrl module returns the current script available', () => {
+    const script1 = document.createElement('script')
+    script1.src = 'https://script.domain.com/path/script-example-1.js'
+    const script2 = document.createElement('script')
+    script2.src = 'https://script.domain.com/path/script-example-2.js'
+
+    expect(utils.currentScriptUrl()).toEqual('')
+
+    document.head.appendChild(script1)
+    document.head.appendChild(script2)
+
+    expect(utils.currentScriptUrl()).toEqual('https://script.domain.com/path/script-example-2.js')
+  })
+
+  test('getBrowserLanguage module returns window.navigator.language data', () => {
+    expect(utils.getBrowserLanguage()).toEqual(window.navigator.language)
+  })
+
+  describe('now module', () => {
+    test('Returns performance.now call response', () => {
+      expect(utils.now()).toEqual(expect.any(Number))
+    })
+
+    test('Returns a valid date time when performance.now is not available', () => {
+      const nowBkp = window.performance.now
+      window.performance.now = null
+
+      expect(utils.now()).toEqual(expect.any(Number))
+
+      window.performance.now = nowBkp
+    })
+  })
+
+  describe('removeArrayItem module', () => {
+    test('removes an item when it exists', () => {
       const a = [1, 2, 3]
       utils.removeArrayItem(a, 2)
       expect(a.indexOf(2)).toEqual(-1)
       expect(a.length).toEqual(2)
     })
 
-    test('does not remove anything when item doesn\'t exist', function() {
+    test('does not remove anything when item doesn\'t exist', () => {
       const a = [1, 2, 3]
       utils.removeArrayItem(a, 4)
       expect(a.length).toEqual(3)
     })
   })
 
-  describe('listContainsIgnoreCase', function() {
-    test('finds when it contains an item', function() {
+  describe('listContainsIgnoreCase module', () => {
+    test('finds when it contains an item', () => {
       const aList = ['audio/aac', 'video/mp4']
       const anItem = 'audio/aac'
 
@@ -172,7 +301,7 @@ describe('Utils', function() {
       expect(doesItContains).toBeTruthy()
     })
 
-    test('finds when it contains a list of any letter case', function() {
+    test('finds when it contains a list of any letter case', () => {
       const aList = ['AUDIO/aac', 'VIDEO/mp4']
       const anItem = 'audio/aac'
 
@@ -181,7 +310,7 @@ describe('Utils', function() {
       expect(doesItContains).toBeTruthy()
     })
 
-    test('finds when it contains an item of any letter case', function() {
+    test('finds when it contains an item of any letter case', () => {
       const aList = ['audio/aac', 'video/mp4']
       const anItem = 'AUDIO/AAC'
 
@@ -190,7 +319,7 @@ describe('Utils', function() {
       expect(doesItContains).toBeTruthy()
     })
 
-    test('does not find when an item is not contained', function() {
+    test('does not find when an item is not contained', () => {
       const aList = ['audio/aac', 'video/mp4']
       const anItem = 'application/x-mpegURL'
 
@@ -199,7 +328,7 @@ describe('Utils', function() {
       expect(doesItContains).toBeFalsy()
     })
 
-    test('does not find when an item is undefined', function() {
+    test('does not find when an item is undefined', () => {
       const aList = ['audio/aac', 'video/mp4']
       const anItem = undefined
 
@@ -208,7 +337,7 @@ describe('Utils', function() {
       expect(doesItContains).toBeFalsy()
     })
 
-    test('does not find when the list is undefined', function() {
+    test('does not find when the list is undefined', () => {
       const aList = undefined
       const anItem = 'audio/aac'
 
@@ -218,45 +347,64 @@ describe('Utils', function() {
     })
   })
 
-  describe('Config', function() {
-    beforeEach(function() {
-      localStorage.removeItem('clappr.localhost.volume')
+  describe('canAutoPlayMedia module', () => {
+    test('Returns true when auto play feature is available', (done) => {
+      window.HTMLMediaElement.prototype.play = () => {
+        return new Promise((resolve) => { setTimeout(() => resolve(), 100) })
+      }
+
+      const callback = (result) => {
+        expect(result).toBeTruthy()
+        done()
+      }
+
+      utils.canAutoPlayMedia(callback)
     })
 
-    test('restores default volume', function() {
-      expect(utils.Config.restore('volume')).toEqual(100)
+    test('Returns false when auto play feature is not available', (done) => {
+      window.HTMLMediaElement.prototype.play = () => {
+        return new Promise((resolve) => { setTimeout(() => resolve(), 300) })
+      }
+
+      const callback = (result) => {
+        expect(result).toBeFalsy()
+        done()
+      }
+
+      utils.canAutoPlayMedia(callback)
     })
 
-    test('restores a persisted volume', function() {
-      utils.Config.persist('volume', 42)
-      expect(utils.Config.restore('volume')).toEqual(42)
-    })
+    test('Checks if auto play feature is available for specifics cases', (done) => {
+      window.HTMLMediaElement.prototype.play = () => { /* do nothing */ }
+      const callback = (result) => {
+        expect(result).toBeTruthy()
+        done()
+      }
 
-    test('returns undefined for unknown key', function() {
-      expect(utils.Config.restore('unknown.key.CAFE')).toEqual(undefined)
+      utils.canAutoPlayMedia(callback, { element: document.createElement('video'), muted: true, inline: true })
     })
   })
 
-  describe('DomRecycler', function() {
-    test('can be configured', function() {
+  describe('DomRecycler module', () => {
+    test('can be configured', () => {
       utils.DomRecycler.configure({ foo: 'bar' })
       expect(utils.DomRecycler.options.foo).toEqual('bar')
       expect(utils.DomRecycler.options.recycleVideo).toBeFalsy()
     })
 
-    test('create a dom element', function() {
+    test('create a dom element', () => {
       const el = utils.DomRecycler.create('div')
       expect(el.tagName).toEqual('DIV')
     })
 
-    test('does not recycle video tag by default', function() {
+    test('does not recycle video tag by default', () => {
       const video1 = utils.DomRecycler.create('video')
       utils.DomRecycler.garbage(video1)
       const video2 = utils.DomRecycler.create('video')
       expect(video1).not.toBe(video2)
     })
 
-    test('recycle video tag if recycleVideo option is set', function() {
+    test('recycle video tag if recycleVideo option is set', () => {
       utils.DomRecycler.configure({ recycleVideo: true })
       const video1 = utils.DomRecycler.create('video')
       utils.DomRecycler.garbage(video1)
@@ -265,10 +413,9 @@ describe('Utils', function() {
     })
   })
 
-  describe('DoubleEventHandler', function() {
-    test('handle double event', function() {
-      const delay = 500
-      const handler = new utils.DoubleEventHandler(delay)
+  describe('DoubleEventHandler module', () => {
+    test('handle double event', (done) => {
+      const handler = new utils.DoubleEventHandler()
       const spy = jest.fn()
       const evt = new Event('touchend')
 
@@ -276,7 +423,8 @@ describe('Utils', function() {
       setTimeout(() => {
         handler.handle(evt, spy)
         expect(spy).toHaveBeenCalledTimes(1)
-      }, delay/2)
+        done()
+      }, 500/2)
     })
   })
 })


### PR DESCRIPTION
## Summary 

This PR adds tests for existent code on `utils.js`.

## Changes

- Improve existent tests cases descriptions;
- Create tests for `assign` module;
- Create tests for `formatTime` module;
- Create tests for `QueryString` module;
- Create tests for `isNumber` module;
- Create tests for `currentScriptUrl` module;
- Create tests for `getBrowserLanguage` module;
- Create tests for `now` module;
- Create tests for `canAutoPlayMedia` module;
- Add more tests for `Config` module;
- Add more tests for `DoubleEventHandler` module;

## How to test

All changes in this PR should not impact any use of the Clappr.
