### PR TITLE
Feature - Configure loading precedence of plugins and playbacks via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,21 @@ player.core.activeContainer.on(Clappr.Events.CONTAINER_STATE_BUFFERING, function
 See all existing events on Clappr [here](https://github.com/clappr/clappr-core/blob/master/src/base/events.js#L227).
 
 #### plugins
-An array used to pass external plugins instances to Clappr. You can pass plugins of any category in this array.
+An object used to config external plugins instances and plugins behaviors to Clappr.
 
-Example:
+```javascript
+{
+  plugins: {
+    core: [CorePlugin],
+    container: [ContainerPlugin],
+    playback: [Playbacks],
+    disableExternalPluginsLoadPrecedence: false,
+    disableExternalPlaybacksLoadPrecedence: false,
+  }
+}
+```
+
+Example of external plugins config:
 
 ```html
 // Playback
@@ -254,9 +266,30 @@ Example:
 
 ```javascript
 {
+  plugins: {
+    container: [ClapprStats],
+    playback: [HlsjsPlayback],
+  }
+}
+```
+
+You can pass plugins of any category in on flat array too. Example:
+
+```javascript
+{
   plugins: [ClapprStats, HlsjsPlayback]
 }
 ```
+
+#### plugins.disableExternalPluginsLoadPrecedence
+> Default Value: `false`
+
+Force external plugins to be loaded after default Clappr plugins.
+
+#### plugins.disableExternalPlaybacksLoadPrecedence
+> Default Value: `false`
+
+Force external playbacks to be loaded after default Clappr playbacks.
 
 #### height
 > Default Value: `360px`

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ An object used to config external plugins instances and plugins behaviors to Cla
     core: [CorePlugin],
     container: [ContainerPlugin],
     playback: [Playbacks],
-    externalPluginsLoadPrecedence: true,
-    externalPlaybacksLoadPrecedence: true,
+    loadExternalPluginsFirst: true,
+    loadExternalPlaybacksFirst: true,
   }
 }
 ```
@@ -281,12 +281,12 @@ You can pass plugins of any category in on flat array too. Example:
 }
 ```
 
-#### plugins.externalPluginsLoadPrecedence
+#### plugins.loadExternalPluginsFirst
 > Default Value: `true`
 
 Force external plugins to be loaded before default Clappr plugins.
 
-#### plugins.externalPlaybacksLoadPrecedence
+#### plugins.loadExternalPlaybacksFirst
 > Default Value: `true`
 
 Force external playbacks to be loaded before default Clappr playbacks.

--- a/README.md
+++ b/README.md
@@ -284,12 +284,12 @@ You can pass plugins of any category in on flat array too. Example:
 #### plugins.externalPluginsLoadPrecedence
 > Default Value: `true`
 
-Force external plugins to be loaded after default Clappr plugins.
+Force external plugins to be loaded before default Clappr plugins.
 
 #### plugins.externalPlaybacksLoadPrecedence
 > Default Value: `true`
 
-Force external playbacks to be loaded after default Clappr playbacks.
+Force external playbacks to be loaded before default Clappr playbacks.
 
 #### height
 > Default Value: `360px`

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ An object used to config external plugins instances and plugins behaviors to Cla
     core: [CorePlugin],
     container: [ContainerPlugin],
     playback: [Playbacks],
-    disableExternalPluginsLoadPrecedence: false,
-    disableExternalPlaybacksLoadPrecedence: false,
+    externalPluginsLoadPrecedence: true,
+    externalPlaybacksLoadPrecedence: true,
   }
 }
 ```
@@ -281,13 +281,13 @@ You can pass plugins of any category in on flat array too. Example:
 }
 ```
 
-#### plugins.disableExternalPluginsLoadPrecedence
-> Default Value: `false`
+#### plugins.externalPluginsLoadPrecedence
+> Default Value: `true`
 
 Force external plugins to be loaded after default Clappr plugins.
 
-#### plugins.disableExternalPlaybacksLoadPrecedence
-> Default Value: `false`
+#### plugins.externalPlaybacksLoadPrecedence
+> Default Value: `true`
 
 Force external playbacks to be loaded after default Clappr playbacks.
 

--- a/src/components/loader/loader.js
+++ b/src/components/loader/loader.js
@@ -203,17 +203,23 @@ export default (() => {
       plugins = this.groupPluginsByType(plugins)
       if (plugins.playback) {
         const playbacks = plugins.playback.filter((playback) => (Loader.checkVersionSupport(playback), true))
-        this.playbackPlugins = this.removeDups(playbacks.concat(this.playbackPlugins))
+        this.playbackPlugins = plugins.disableExternalPlaybacksLoadPrecedence
+          ? this.removeDups(this.playbackPlugins.concat(playbacks))
+          : this.removeDups(playbacks.concat(this.playbackPlugins))
       }
 
       if (plugins.container) {
         const containerPlugins = plugins.container.filter((plugin) => (Loader.checkVersionSupport(plugin), true))
-        this.containerPlugins = this.removeDups(containerPlugins.concat(this.containerPlugins))
+        this.containerPlugins = plugins.disableExternalPluginsLoadPrecedence
+          ? this.removeDups(this.containerPlugins.concat(containerPlugins))
+          : this.removeDups(containerPlugins.concat(this.containerPlugins))
       }
 
       if (plugins.core) {
         const corePlugins = plugins.core.filter((plugin) => (Loader.checkVersionSupport(plugin), true))
-        this.corePlugins = this.removeDups(corePlugins.concat(this.corePlugins))
+        this.corePlugins = plugins.disableExternalPluginsLoadPrecedence
+          ? this.removeDups(this.corePlugins.concat(corePlugins))
+          : this.removeDups(corePlugins.concat(this.corePlugins))
       }
     }
 

--- a/src/components/loader/loader.js
+++ b/src/components/loader/loader.js
@@ -202,26 +202,34 @@ export default (() => {
      * @param {Object} plugins the config object with all plugins
      */
     addExternalPlugins(plugins) {
+      const externalPluginsPrecedence = typeof plugins.externalPluginsLoadPrecedence === 'boolean'
+        ? plugins.externalPluginsLoadPrecedence
+        : true
+      const externalPlaybacksPrecedence = typeof plugins.externalPlaybacksLoadPrecedence === 'boolean'
+        ? plugins.externalPluginsLoadPrecedence
+        : true
+
       plugins = this.groupPluginsByType(plugins)
+
       if (plugins.playback) {
         const playbacks = plugins.playback.filter((playback) => (Loader.checkVersionSupport(playback), true))
-        this.playbackPlugins = plugins.disableExternalPlaybacksLoadPrecedence
-          ? this.removeDups(this.playbackPlugins.concat(playbacks), true)
-          : this.removeDups(playbacks.concat(this.playbackPlugins))
+        this.playbackPlugins = externalPlaybacksPrecedence
+          ? this.removeDups(playbacks.concat(this.playbackPlugins))
+          : this.removeDups(this.playbackPlugins.concat(playbacks), true)
       }
 
       if (plugins.container) {
         const containerPlugins = plugins.container.filter((plugin) => (Loader.checkVersionSupport(plugin), true))
-        this.containerPlugins = plugins.disableExternalPluginsLoadPrecedence
-          ? this.removeDups(this.containerPlugins.concat(containerPlugins), true)
-          : this.removeDups(containerPlugins.concat(this.containerPlugins))
+        this.containerPlugins = externalPluginsPrecedence
+          ? this.removeDups(containerPlugins.concat(this.containerPlugins))
+          : this.removeDups(this.containerPlugins.concat(containerPlugins), true)
       }
 
       if (plugins.core) {
         const corePlugins = plugins.core.filter((plugin) => (Loader.checkVersionSupport(plugin), true))
-        this.corePlugins = plugins.disableExternalPluginsLoadPrecedence
-          ? this.removeDups(this.corePlugins.concat(corePlugins), true)
-          : this.removeDups(corePlugins.concat(this.corePlugins))
+        this.corePlugins = externalPluginsPrecedence
+          ? this.removeDups(corePlugins.concat(this.corePlugins))
+          : this.removeDups(this.corePlugins.concat(corePlugins), true)
       }
     }
 

--- a/src/components/loader/loader.js
+++ b/src/components/loader/loader.js
@@ -202,32 +202,32 @@ export default (() => {
      * @param {Object} plugins the config object with all plugins
      */
     addExternalPlugins(plugins) {
-      const externalPluginsPrecedence = typeof plugins.externalPluginsLoadPrecedence === 'boolean'
-        ? plugins.externalPluginsLoadPrecedence
+      const loadExternalPluginsFirst = typeof plugins.loadExternalPluginsFirst === 'boolean'
+        ? plugins.loadExternalPluginsFirst
         : true
-      const externalPlaybacksPrecedence = typeof plugins.externalPlaybacksLoadPrecedence === 'boolean'
-        ? plugins.externalPluginsLoadPrecedence
+      const loadExternalPlaybacksFirst = typeof plugins.loadExternalPlaybacksFirst === 'boolean'
+        ? plugins.loadExternalPlaybacksFirst
         : true
 
       plugins = this.groupPluginsByType(plugins)
 
       if (plugins.playback) {
         const playbacks = plugins.playback.filter((playback) => (Loader.checkVersionSupport(playback), true))
-        this.playbackPlugins = externalPlaybacksPrecedence
+        this.playbackPlugins = loadExternalPlaybacksFirst
           ? this.removeDups(playbacks.concat(this.playbackPlugins))
           : this.removeDups(this.playbackPlugins.concat(playbacks), true)
       }
 
       if (plugins.container) {
         const containerPlugins = plugins.container.filter((plugin) => (Loader.checkVersionSupport(plugin), true))
-        this.containerPlugins = externalPluginsPrecedence
+        this.containerPlugins = loadExternalPluginsFirst
           ? this.removeDups(containerPlugins.concat(this.containerPlugins))
           : this.removeDups(this.containerPlugins.concat(containerPlugins), true)
       }
 
       if (plugins.core) {
         const corePlugins = plugins.core.filter((plugin) => (Loader.checkVersionSupport(plugin), true))
-        this.corePlugins = externalPluginsPrecedence
+        this.corePlugins = loadExternalPluginsFirst
           ? this.removeDups(corePlugins.concat(this.corePlugins))
           : this.removeDups(this.corePlugins.concat(corePlugins), true)
       }

--- a/src/components/loader/loader.js
+++ b/src/components/loader/loader.js
@@ -178,8 +178,10 @@ export default (() => {
       return plugins
     }
 
-    removeDups(list) {
+    removeDups(list, useReversePrecedence = false) {
       const groupUp = (plugins, plugin) => {
+        if (plugins[plugin.prototype.name] && useReversePrecedence) return plugins
+
         plugins[plugin.prototype.name] && delete plugins[plugin.prototype.name]
         plugins[plugin.prototype.name] = plugin
         return plugins
@@ -204,21 +206,21 @@ export default (() => {
       if (plugins.playback) {
         const playbacks = plugins.playback.filter((playback) => (Loader.checkVersionSupport(playback), true))
         this.playbackPlugins = plugins.disableExternalPlaybacksLoadPrecedence
-          ? this.removeDups(this.playbackPlugins.concat(playbacks))
+          ? this.removeDups(this.playbackPlugins.concat(playbacks), true)
           : this.removeDups(playbacks.concat(this.playbackPlugins))
       }
 
       if (plugins.container) {
         const containerPlugins = plugins.container.filter((plugin) => (Loader.checkVersionSupport(plugin), true))
         this.containerPlugins = plugins.disableExternalPluginsLoadPrecedence
-          ? this.removeDups(this.containerPlugins.concat(containerPlugins))
+          ? this.removeDups(this.containerPlugins.concat(containerPlugins), true)
           : this.removeDups(containerPlugins.concat(this.containerPlugins))
       }
 
       if (plugins.core) {
         const corePlugins = plugins.core.filter((plugin) => (Loader.checkVersionSupport(plugin), true))
         this.corePlugins = plugins.disableExternalPluginsLoadPrecedence
-          ? this.removeDups(this.corePlugins.concat(corePlugins))
+          ? this.removeDups(this.corePlugins.concat(corePlugins), true)
           : this.removeDups(corePlugins.concat(this.corePlugins))
       }
     }

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -152,6 +152,88 @@ describe('Loader', function() {
       expect(loader.corePlugins.length).toEqual(nativeCorePluginsCount + 1)
     })
 
+    test('supports load externals before default plugins for disableExternalPluginsLoadPrecedence option not configured', () => {
+      const defaultContainerPlugin = ContainerPlugin.extend({ name: 'default_container_plugin' })
+      const defaultCorePlugin = CorePlugin.extend({ name: 'default_core_plugin' })
+
+      Loader.registerPlugin(defaultContainerPlugin)
+      Loader.registerPlugin(defaultCorePlugin)
+
+      const loader = new Loader()
+
+      const externalContainerPlugin = ContainerPlugin.extend({ name: 'external_container_plugin' })
+      const externalCorePlugin = CorePlugin.extend({ name: 'external_core_plugin' })
+
+      loader.addExternalPlugins({ core: [externalCorePlugin], container: [externalContainerPlugin] })
+
+      expect(loader.containerPlugins[0].prototype.name).toEqual(externalContainerPlugin.prototype.name)
+      expect(loader.containerPlugins[1].prototype.name).toEqual(defaultContainerPlugin.prototype.name)
+
+      expect(loader.corePlugins[0].prototype.name).toEqual(externalCorePlugin.prototype.name)
+      expect(loader.corePlugins[1].prototype.name).toEqual(defaultCorePlugin.prototype.name)
+
+      Loader.unregisterPlugin(defaultContainerPlugin.prototype.name)
+      Loader.unregisterPlugin(defaultCorePlugin.prototype.name)
+    })
+
+    test('supports load externals before default playbacks for disableExternalPlaybacksLoadPrecedence option not configured', () => {
+      const defaultPlaybackPlugin = PlaybackPlugin.extend({ name: 'default_playback_plugin' })
+
+      Loader.registerPlayback(defaultPlaybackPlugin)
+
+      const loader = new Loader()
+
+      const externalPlaybackPlugin = PlaybackPlugin.extend({ name: 'external_playback_plugin' })
+
+      loader.addExternalPlugins({ playback: [externalPlaybackPlugin] })
+
+      expect(loader.playbackPlugins[0].prototype.name).toEqual(externalPlaybackPlugin.prototype.name)
+      expect(loader.playbackPlugins[1].prototype.name).toEqual(defaultPlaybackPlugin.prototype.name)
+
+      Loader.unregisterPlayback(defaultPlaybackPlugin.prototype.name)
+    })
+
+    test('supports load externals after default plugins for disableExternalPluginsLoadPrecedence option configured', () => {
+      const defaultContainerPlugin = ContainerPlugin.extend({ name: 'default_container_plugin' })
+      const defaultCorePlugin = CorePlugin.extend({ name: 'default_core_plugin' })
+
+      Loader.registerPlugin(defaultContainerPlugin)
+      Loader.registerPlugin(defaultCorePlugin)
+
+      const loader = new Loader()
+
+      const externalContainerPlugin = ContainerPlugin.extend({ name: 'external_container_plugin' })
+      const externalCorePlugin = CorePlugin.extend({ name: 'external_core_plugin' })
+
+      loader.addExternalPlugins({ disableExternalPluginsLoadPrecedence: true, core: [externalCorePlugin], container: [externalContainerPlugin] })
+
+      expect(loader.containerPlugins[0].prototype.name).toEqual('default_container_plugin')
+      expect(loader.containerPlugins[1].prototype.name).toEqual('external_container_plugin')
+
+      expect(loader.corePlugins[0].prototype.name).toEqual('default_core_plugin')
+      expect(loader.corePlugins[1].prototype.name).toEqual('external_core_plugin')
+
+      Loader.unregisterPlugin(defaultContainerPlugin.prototype.name)
+      Loader.unregisterPlugin(defaultCorePlugin.prototype.name)
+    })
+
+    test('supports load externals after default playbacks for disableExternalPlaybacksLoadPrecedence option configured', () => {
+      const defaultPlaybackPlugin = PlaybackPlugin.extend({ name: 'default_playback_plugin' })
+
+      Loader.registerPlayback(defaultPlaybackPlugin)
+
+      const loader = new Loader()
+
+      const externalPlaybackPlugin = PlaybackPlugin.extend({ name: 'external_playback_plugin' })
+
+      loader.addExternalPlugins({ disableExternalPlaybacksLoadPrecedence: true, playback: [externalPlaybackPlugin] })
+
+      expect(loader.playbackPlugins[0].prototype.name).toEqual(defaultPlaybackPlugin.prototype.name)
+      expect(loader.playbackPlugins[1].prototype.name).toEqual(externalPlaybackPlugin.prototype.name)
+
+      Loader.unregisterPlayback(defaultPlaybackPlugin.prototype.name)
+    })
+
     describe('overriding plugins', () => {
       beforeEach(() => {
         loader.containerPlugins = [

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -152,7 +152,7 @@ describe('Loader', function() {
       expect(loader.corePlugins.length).toEqual(nativeCorePluginsCount + 1)
     })
 
-    test('supports load externals before default plugins for externalPluginsLoadPrecedence option not configured', () => {
+    test('supports load externals before default plugins for loadExternalPluginsFirst option not configured', () => {
       const defaultContainerPlugin = ContainerPlugin.extend({ name: 'default_container_plugin' })
       const defaultCorePlugin = CorePlugin.extend({ name: 'default_core_plugin' })
 
@@ -176,7 +176,7 @@ describe('Loader', function() {
       Loader.unregisterPlugin(defaultCorePlugin.prototype.name)
     })
 
-    test('supports load externals before default playbacks for externalPlaybacksLoadPrecedence option not configured', () => {
+    test('supports load externals before default playbacks for loadExternalPlaybacksFirst option not configured', () => {
       const defaultPlaybackPlugin = PlaybackPlugin.extend({ name: 'default_playback_plugin' })
 
       Loader.registerPlayback(defaultPlaybackPlugin)
@@ -193,7 +193,7 @@ describe('Loader', function() {
       Loader.unregisterPlayback(defaultPlaybackPlugin.prototype.name)
     })
 
-    test('supports load externals after default plugins for externalPluginsLoadPrecedence option configured with false value', () => {
+    test('supports load externals after default plugins for loadExternalPluginsFirst option configured with false value', () => {
       const defaultContainerPlugin = ContainerPlugin.extend({ name: 'default_container_plugin' })
       const defaultCorePlugin = CorePlugin.extend({ name: 'default_core_plugin' })
 
@@ -205,7 +205,7 @@ describe('Loader', function() {
       const externalContainerPlugin = ContainerPlugin.extend({ name: 'external_container_plugin' })
       const externalCorePlugin = CorePlugin.extend({ name: 'external_core_plugin' })
 
-      loader.addExternalPlugins({ externalPluginsLoadPrecedence: false, core: [externalCorePlugin], container: [externalContainerPlugin] })
+      loader.addExternalPlugins({ loadExternalPluginsFirst: false, core: [externalCorePlugin], container: [externalContainerPlugin] })
 
       expect(loader.containerPlugins[0].prototype.name).toEqual('default_container_plugin')
       expect(loader.containerPlugins[1].prototype.name).toEqual('external_container_plugin')
@@ -217,7 +217,7 @@ describe('Loader', function() {
       Loader.unregisterPlugin(defaultCorePlugin.prototype.name)
     })
 
-    test('supports load externals after default playbacks for externalPlaybacksLoadPrecedence option configured with false value', () => {
+    test('supports load externals after default playbacks for loadExternalPlaybacksFirst option configured with false value', () => {
       const defaultPlaybackPlugin = PlaybackPlugin.extend({ name: 'default_playback_plugin' })
 
       Loader.registerPlayback(defaultPlaybackPlugin)
@@ -226,7 +226,7 @@ describe('Loader', function() {
 
       const externalPlaybackPlugin = PlaybackPlugin.extend({ name: 'external_playback_plugin' })
 
-      loader.addExternalPlugins({ externalPlaybacksLoadPrecedence: false, playback: [externalPlaybackPlugin] })
+      loader.addExternalPlugins({ loadExternalPlaybacksFirst: false, playback: [externalPlaybackPlugin] })
 
       expect(loader.playbackPlugins[0].prototype.name).toEqual(defaultPlaybackPlugin.prototype.name)
       expect(loader.playbackPlugins[1].prototype.name).toEqual(externalPlaybackPlugin.prototype.name)
@@ -283,7 +283,7 @@ describe('Loader', function() {
       })
     })
 
-    test('respected even when externalPluginsLoadPrecedence is configured with false value', () => {
+    test('respected even when loadExternalPluginsFirst is configured with false value', () => {
       const defaultContainerPlugin = ContainerPlugin.extend({ name: 'container_plugin' })
       const defaultCorePlugin = CorePlugin.extend({ name: 'core_plugin' })
 
@@ -295,7 +295,7 @@ describe('Loader', function() {
       const externalContainerPlugin = ContainerPlugin.extend({ name: 'container_plugin' })
       const externalCorePlugin = CorePlugin.extend({ name: 'core_plugin' })
 
-      loader.addExternalPlugins({ externalPluginsLoadPrecedence: false, core: [externalCorePlugin], container: [externalContainerPlugin] })
+      loader.addExternalPlugins({ loadExternalPluginsFirst: false, core: [externalCorePlugin], container: [externalContainerPlugin] })
 
       expect(loader.containerPlugins.length).toEqual(1)
       expect(loader.containerPlugins[0].prototype.name).toEqual(externalContainerPlugin.prototype.name)
@@ -307,7 +307,7 @@ describe('Loader', function() {
       Loader.unregisterPlugin(defaultCorePlugin.prototype.name)
     })
 
-    test('respected even when externalPlaybacksLoadPrecedence is configured with false value', () => {
+    test('respected even when loadExternalPlaybacksFirst is configured with false value', () => {
       const defaultPlaybackPlugin = PlaybackPlugin.extend({ name: 'playback_plugin' })
 
       Loader.registerPlayback(defaultPlaybackPlugin)
@@ -316,7 +316,7 @@ describe('Loader', function() {
 
       const externalPlaybackPlugin = PlaybackPlugin.extend({ name: 'playback_plugin' })
 
-      loader.addExternalPlugins({ externalPlaybacksLoadPrecedence: false, playback: [externalPlaybackPlugin] })
+      loader.addExternalPlugins({ loadExternalPlaybacksFirst: false, playback: [externalPlaybackPlugin] })
 
       expect(loader.playbackPlugins.length).toEqual(1)
       expect(loader.playbackPlugins[0].prototype.name).toEqual(externalPlaybackPlugin.prototype.name)

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -283,6 +283,46 @@ describe('Loader', function() {
       })
     })
 
+    test('respected even when disableExternalPluginsLoadPrecedence is configured', () => {
+      const defaultContainerPlugin = ContainerPlugin.extend({ name: 'container_plugin' })
+      const defaultCorePlugin = CorePlugin.extend({ name: 'core_plugin' })
+
+      Loader.registerPlugin(defaultContainerPlugin)
+      Loader.registerPlugin(defaultCorePlugin)
+
+      const loader = new Loader()
+
+      const externalContainerPlugin = ContainerPlugin.extend({ name: 'container_plugin' })
+      const externalCorePlugin = CorePlugin.extend({ name: 'core_plugin' })
+
+      loader.addExternalPlugins({ disableExternalPluginsLoadPrecedence: true, core: [externalCorePlugin], container: [externalContainerPlugin] })
+
+      expect(loader.containerPlugins.length).toEqual(1)
+      expect(loader.containerPlugins[0].prototype.name).toEqual(externalContainerPlugin.prototype.name)
+
+      expect(loader.corePlugins.length).toEqual(1)
+      expect(loader.corePlugins[0].prototype.name).toEqual(externalCorePlugin.prototype.name)
+
+      Loader.unregisterPlugin(defaultContainerPlugin.prototype.name)
+      Loader.unregisterPlugin(defaultCorePlugin.prototype.name)
+    })
+
+    test('respected even when disableExternalPlaybacksLoadPrecedence is configured', () => {
+      const defaultPlaybackPlugin = PlaybackPlugin.extend({ name: 'playback_plugin' })
+
+      Loader.registerPlayback(defaultPlaybackPlugin)
+
+      const loader = new Loader()
+
+      const externalPlaybackPlugin = PlaybackPlugin.extend({ name: 'playback_plugin' })
+
+      loader.addExternalPlugins({ disableExternalPlaybacksLoadPrecedence: true, playback: [externalPlaybackPlugin] })
+
+      expect(loader.playbackPlugins.length).toEqual(1)
+      expect(loader.playbackPlugins[0].prototype.name).toEqual(externalPlaybackPlugin.prototype.name)
+
+      Loader.unregisterPlayback(defaultPlaybackPlugin.prototype.name)
+    })
   })
 
   describe('validateExternalPluginsType function', () => {

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -152,7 +152,7 @@ describe('Loader', function() {
       expect(loader.corePlugins.length).toEqual(nativeCorePluginsCount + 1)
     })
 
-    test('supports load externals before default plugins for disableExternalPluginsLoadPrecedence option not configured', () => {
+    test('supports load externals before default plugins for externalPluginsLoadPrecedence option not configured', () => {
       const defaultContainerPlugin = ContainerPlugin.extend({ name: 'default_container_plugin' })
       const defaultCorePlugin = CorePlugin.extend({ name: 'default_core_plugin' })
 
@@ -176,7 +176,7 @@ describe('Loader', function() {
       Loader.unregisterPlugin(defaultCorePlugin.prototype.name)
     })
 
-    test('supports load externals before default playbacks for disableExternalPlaybacksLoadPrecedence option not configured', () => {
+    test('supports load externals before default playbacks for externalPlaybacksLoadPrecedence option not configured', () => {
       const defaultPlaybackPlugin = PlaybackPlugin.extend({ name: 'default_playback_plugin' })
 
       Loader.registerPlayback(defaultPlaybackPlugin)
@@ -193,7 +193,7 @@ describe('Loader', function() {
       Loader.unregisterPlayback(defaultPlaybackPlugin.prototype.name)
     })
 
-    test('supports load externals after default plugins for disableExternalPluginsLoadPrecedence option configured', () => {
+    test('supports load externals after default plugins for externalPluginsLoadPrecedence option configured with false value', () => {
       const defaultContainerPlugin = ContainerPlugin.extend({ name: 'default_container_plugin' })
       const defaultCorePlugin = CorePlugin.extend({ name: 'default_core_plugin' })
 
@@ -205,7 +205,7 @@ describe('Loader', function() {
       const externalContainerPlugin = ContainerPlugin.extend({ name: 'external_container_plugin' })
       const externalCorePlugin = CorePlugin.extend({ name: 'external_core_plugin' })
 
-      loader.addExternalPlugins({ disableExternalPluginsLoadPrecedence: true, core: [externalCorePlugin], container: [externalContainerPlugin] })
+      loader.addExternalPlugins({ externalPluginsLoadPrecedence: false, core: [externalCorePlugin], container: [externalContainerPlugin] })
 
       expect(loader.containerPlugins[0].prototype.name).toEqual('default_container_plugin')
       expect(loader.containerPlugins[1].prototype.name).toEqual('external_container_plugin')
@@ -217,7 +217,7 @@ describe('Loader', function() {
       Loader.unregisterPlugin(defaultCorePlugin.prototype.name)
     })
 
-    test('supports load externals after default playbacks for disableExternalPlaybacksLoadPrecedence option configured', () => {
+    test('supports load externals after default playbacks for externalPlaybacksLoadPrecedence option configured with false value', () => {
       const defaultPlaybackPlugin = PlaybackPlugin.extend({ name: 'default_playback_plugin' })
 
       Loader.registerPlayback(defaultPlaybackPlugin)
@@ -226,7 +226,7 @@ describe('Loader', function() {
 
       const externalPlaybackPlugin = PlaybackPlugin.extend({ name: 'external_playback_plugin' })
 
-      loader.addExternalPlugins({ disableExternalPlaybacksLoadPrecedence: true, playback: [externalPlaybackPlugin] })
+      loader.addExternalPlugins({ externalPlaybacksLoadPrecedence: false, playback: [externalPlaybackPlugin] })
 
       expect(loader.playbackPlugins[0].prototype.name).toEqual(defaultPlaybackPlugin.prototype.name)
       expect(loader.playbackPlugins[1].prototype.name).toEqual(externalPlaybackPlugin.prototype.name)
@@ -283,7 +283,7 @@ describe('Loader', function() {
       })
     })
 
-    test('respected even when disableExternalPluginsLoadPrecedence is configured', () => {
+    test('respected even when externalPluginsLoadPrecedence is configured with false value', () => {
       const defaultContainerPlugin = ContainerPlugin.extend({ name: 'container_plugin' })
       const defaultCorePlugin = CorePlugin.extend({ name: 'core_plugin' })
 
@@ -295,7 +295,7 @@ describe('Loader', function() {
       const externalContainerPlugin = ContainerPlugin.extend({ name: 'container_plugin' })
       const externalCorePlugin = CorePlugin.extend({ name: 'core_plugin' })
 
-      loader.addExternalPlugins({ disableExternalPluginsLoadPrecedence: true, core: [externalCorePlugin], container: [externalContainerPlugin] })
+      loader.addExternalPlugins({ externalPluginsLoadPrecedence: false, core: [externalCorePlugin], container: [externalContainerPlugin] })
 
       expect(loader.containerPlugins.length).toEqual(1)
       expect(loader.containerPlugins[0].prototype.name).toEqual(externalContainerPlugin.prototype.name)
@@ -307,7 +307,7 @@ describe('Loader', function() {
       Loader.unregisterPlugin(defaultCorePlugin.prototype.name)
     })
 
-    test('respected even when disableExternalPlaybacksLoadPrecedence is configured', () => {
+    test('respected even when externalPlaybacksLoadPrecedence is configured with false value', () => {
       const defaultPlaybackPlugin = PlaybackPlugin.extend({ name: 'playback_plugin' })
 
       Loader.registerPlayback(defaultPlaybackPlugin)
@@ -316,7 +316,7 @@ describe('Loader', function() {
 
       const externalPlaybackPlugin = PlaybackPlugin.extend({ name: 'playback_plugin' })
 
-      loader.addExternalPlugins({ disableExternalPlaybacksLoadPrecedence: true, playback: [externalPlaybackPlugin] })
+      loader.addExternalPlugins({ externalPlaybacksLoadPrecedence: false, playback: [externalPlaybackPlugin] })
 
       expect(loader.playbackPlugins.length).toEqual(1)
       expect(loader.playbackPlugins[0].prototype.name).toEqual(externalPlaybackPlugin.prototype.name)


### PR DESCRIPTION
## Summary

This PR adds the possibility to change the external plugins/playbacks load precedence from `before default plugins/playbacks` to `after default plugins/playbacks` via the new options `loadExternalPluginsFirst` and `loadExternalPlaybacksFirst`. 

## Changes

* Create new option `plugins.loadExternalPluginsFirst`;
* Create new option `plugins.loadExternalPlaybacksFirst`;
* Update `addExternalPlugins` method the order to `concat` external and default plugins according to the new options;
* Update `removeDups` method to remain the feature for overwriting default plugins with external plugins.

## How to test

### To test the precedence change:

Change the `public/j/clappr-config.js` for this:

``` javascript
var playerElement = document.getElementById("player-wrapper");

class TestPlugin extends Clappr.CorePlugin {
  get name() { return 'test_plugin' }
  get supportedVersion() { return { min: Clappr.version } }
}

player = new Clappr.Player({
  source: urlParams.src || 'http://clappr.io/highline.mp4',
  poster: urlParams.poster || 'http://clappr.io/poster.png',
  mute: true,
  autoPlay: true,
  height: 360,
  width: 640,
  playback: {
    controls: true,
  },
  plugins: {
    core: [TestPlugin],
  },
});

player.attachTo(playerElement);
```

* Run Clappr locally;
* Open the developer tools on the browser of your preference in the `console` tab;
* Run this snippet `player.core.plugins.forEach(plugin => console.log(plugin.name))`;
  * The first plugin name logged should be the `test_plugin`;
* Configure the new option `loadExternalPluginsFirst`;
  * `{ plugins: { loadExternalPluginsFirst: true, core: [TestPlugin] } }`;
* Run this code snippet `player.core.plugins.forEach(plugin => console.log(plugin.name))` on console again;
  * This time the last plugin name logged should be the `test_plugin`;

The same behaviors are expected for tests with `playbacks` and `loadExternalPlaybacksFirst`

### To test the overwrite feature with the new options:

* Change the getter `name` of `TestPlugin` to return one existent plugin name on the project;
  * `class TestPlugin extends Clappr.CorePlugin { get name() { return 'strings' },  ... }`
* Add one new getter do help with validation;
  * `class TestPlugin extends Clappr.CorePlugin { ..., get test() { return 'getter test'} }`
* Run Clappr locally with the option with and without the option `loadExternalPluginsFirst` configured;
* Open the developer tools on the browser of your preference in the `console` tab;
* Run this code snippet `player.core.plugins.forEach(plugin => console.log(plugin.name))`;
  * Only one plugin with name `strings` is expected;
* Run this code snippet `player.getPlugin('strings').test` to prove that is our external plugin;
  * The string `getter test` should be printed;

The same behaviors are expected for tests with `playbacks` and `loadExternalPlaybacksFirst`