### PR TITLE
Refactor - keep the precedence smooth

### DIFF
--- a/src/components/core/public/style.scss
+++ b/src/components/core/public/style.scss
@@ -25,12 +25,15 @@
   }
 
   * {
-    max-width: none;
     box-sizing: inherit;
-    float: none;
   }
 
-  div {
+  > * {
+    float: none;
+    max-width: none;
+  }
+
+  > div {
     display: block;
   }
 


### PR DESCRIPTION
The main ideia is to maintain the definition used right now inside [data-control] but it should avoid to set it deeply in DOM tree when it is already the default value because it is causing some conflicts for children with simple CSS class precedence.

### Problem
#### deep DOM element with CSS class not getting the defined style due to priority of current CSS rule
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/770092/88968357-96c1fb80-d285-11ea-84e0-9b65542db078.gif)

### How to test

```
var playerElement = document.getElementById("player-wrapper");

class TestPlugin extends Clappr.UICorePlugin {
  get name() { return 'test_plugin' }
  get supportedVersion() { return { min: Clappr.version } }
  get template() { return Clappr.template(`<div class="plugin-test-wrapper" data-plugin-test></div>`) }
  get attributes() {
    return {
      'class': 'plugin-test',
      'data-plugin-test': ''
    }
  }
  render() {
    let styleOption = { baseUrl: this.options.baseUrl, playerId: this.options.playerId }
    let style = Clappr.Styler.getStyleFor('.plugin-test { display: inline-block; } .plugin-test-wrapper { display: inline-block; }', styleOption)
    this.$el.html(this.template())
    this.$el.append(style[0])
    this.core.$el.append(this.el)
  }
}

player = new Clappr.Player({
  source: urlParams.src || 'http://clappr.io/highline.mp4',
  poster: urlParams.poster || 'http://clappr.io/poster.png',
  mute: true,
  autoPlay: true,
  height: 360,
  width: 640,
  playback: {
    controls: true,
  },
  plugins: {
    core: [TestPlugin]
  },
});

player.attachTo(playerElement);
```
#### Inner element from `[data-player]`
##### it uses the value defined from CSS for inner content of [data-player]
<img width="603" alt="Captura de Tela 2020-08-04 às 15 19 53" src="https://user-images.githubusercontent.com/770092/89330171-42909000-d666-11ea-8de3-d50f8878fb32.png">

#### Child element deep into DOM of `[data-player]`
##### it uses the value defined from Browser
<img width="694" alt="Captura de Tela 2020-08-04 às 15 20 07" src="https://user-images.githubusercontent.com/770092/89330184-46bcad80-d666-11ea-82fa-81b7b960edf2.png">

#### Child element deep into DOM of `[data-player]` with simple defined class without another CSS precedence
##### it uses the value defined from Plugin
<img width="693" alt="Captura de Tela 2020-08-04 às 15 25 58" src="https://user-images.githubusercontent.com/770092/89330671-ff82ec80-d666-11ea-8a7d-f7e7451534da.png">



It must not change any visual element