### PR TITLE
 Tests - Increase test coverage for BaseObject existent code

### DIFF
--- a/src/base/base_object/base_object.js
+++ b/src/base/base_object/base_object.js
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import { uniqueId } from '../../utils'
-import Events from '../events'
+import { uniqueId } from '@/utils'
+import Events from '@/base/events'
 
 /**
  * @class BaseObject

--- a/src/base/base_object/base_object.test.js
+++ b/src/base/base_object/base_object.test.js
@@ -1,6 +1,13 @@
 import BaseObject from './base_object'
 
 describe('BaseObject', () => {
+  test('has a getter that returns the set of options', () => {
+    const options = { clappr: 'is awesome!' }
+    const baseObject = new BaseObject(options)
+
+    expect(baseObject.options).toEqual(options)
+  })
+
   test('has unique id', () => {
     const baseObject = new BaseObject()
     const baseObject2 = new BaseObject()

--- a/src/base/base_object/base_object.test.js
+++ b/src/base/base_object/base_object.test.js
@@ -1,6 +1,6 @@
 import BaseObject from './base_object'
 
-describe('BaseObject', function() {
+describe('BaseObject', () => {
   test('has unique id', () => {
     const baseObject = new BaseObject()
     const baseObject2 = new BaseObject()

--- a/src/base/base_object/base_object.test.js
+++ b/src/base/base_object/base_object.test.js
@@ -11,7 +11,8 @@ describe('BaseObject', () => {
   test('has unique id', () => {
     const baseObject = new BaseObject()
     const baseObject2 = new BaseObject()
-    expect(baseObject.uniqueId).toEqual('o1')
-    expect(baseObject2.uniqueId).toEqual('o2')
+
+    expect(baseObject.uniqueId).toEqual('o2')
+    expect(baseObject2.uniqueId).toEqual('o3')
   })
 })


### PR DESCRIPTION
## Summary 

This PR adds tests for existent code on `base_object.js`.

## Changes

- Use path alias to import modules on `base_object.js`
- Create tests for `options` getter;
- Update existent tests;

## How to test

All changes in this PR should not impact any use of the Clappr.
