### PR TITLE
 Tests - Increase test coverage for ContainerPlugin existent code

### DIFF
--- a/src/base/container_plugin/container_plugin.js
+++ b/src/base/container_plugin/container_plugin.js
@@ -1,6 +1,6 @@
-import BaseObject from '../base_object'
-import ErrorMixin from '../error_mixin'
-import { extend } from '../../utils'
+import BaseObject from '@/base/base_object'
+import ErrorMixin from '@/base/error_mixin'
+import { extend } from '@/utils'
 
 /**
  * The base class for a container plugin

--- a/src/base/container_plugin/container_plugin.test.js
+++ b/src/base/container_plugin/container_plugin.test.js
@@ -1,4 +1,5 @@
 import ContainerPlugin from './container_plugin'
+import ErrorMixin from '@/base/error_mixin'
 
 describe('Container Plugin', () => {
   describe('#constructor', () => {
@@ -40,6 +41,13 @@ describe('Container Plugin', () => {
     plugin.enable()
 
     expect(plugin.enabled).toBeTruthy()
+  })
+
+  test('receives createdError method from ErrorMixin', () => {
+    const plugin = new ContainerPlugin({})
+
+    expect(plugin.createError).not.toBeUndefined()
+    expect(plugin.createError).toEqual(ErrorMixin.createError)
   })
 
   test('stops listening when disable an enabled plugin', () => {

--- a/src/base/container_plugin/container_plugin.test.js
+++ b/src/base/container_plugin/container_plugin.test.js
@@ -22,7 +22,7 @@ describe('Container Plugin', () => {
     })
   })
 
-  test('disables', () => {
+  test('can be disabled after your creation', () => {
     const plugin = new ContainerPlugin({})
 
     plugin.disable()
@@ -39,7 +39,7 @@ describe('Container Plugin', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
-  test('doesnt stops listening when disable a disabled plugin', () => {
+  test('doesn\'t stops listening when disable a disabled plugin', () => {
     const plugin = new ContainerPlugin({})
     const spy = jest.spyOn(plugin, 'stopListening')
 

--- a/src/base/container_plugin/container_plugin.test.js
+++ b/src/base/container_plugin/container_plugin.test.js
@@ -30,6 +30,18 @@ describe('Container Plugin', () => {
     expect(plugin.enabled).toBeFalsy()
   })
 
+  test('can be enabled after your creation', () => {
+    const plugin = new ContainerPlugin({})
+
+    plugin.disable()
+
+    expect(plugin.enabled).toBeFalsy()
+
+    plugin.enable()
+
+    expect(plugin.enabled).toBeTruthy()
+  })
+
   test('stops listening when disable an enabled plugin', () => {
     const plugin = new ContainerPlugin({})
     const spy = jest.spyOn(plugin, 'stopListening')

--- a/src/base/container_plugin/container_plugin.test.js
+++ b/src/base/container_plugin/container_plugin.test.js
@@ -88,4 +88,10 @@ describe('Container Plugin', () => {
 
     expect(spy).not.toHaveBeenCalled()
   })
+
+  test('can be created via extends method', () => {
+    const plugin = ContainerPlugin.extend({ name: 'test_plugin' })
+
+    expect(plugin.prototype instanceof ContainerPlugin).toBeTruthy()
+  })
 })

--- a/src/base/container_plugin/container_plugin.test.js
+++ b/src/base/container_plugin/container_plugin.test.js
@@ -1,8 +1,8 @@
 import ContainerPlugin from './container_plugin'
 
-describe('Container Plugin', function() {
+describe('Container Plugin', () => {
   describe('#constructor', () => {
-    test('enables', function() {
+    test('enables the plugin', () => {
       const plugin = new ContainerPlugin({})
 
       expect(plugin.enabled).toBeTruthy()


### PR DESCRIPTION
## Summary 

This PR adds tests for existent code on `container_plugin.js`.

## Changes

- Use path alias to import modules on `container_plugin.js`
- Create tests for `enable` method;
- Create tests for `ErrorMixin` assignment;
- Create tests for `extend` feature;

## How to test

All changes in this PR should not impact any use of the Clappr.
