### PR TITLE
 Tests - Increase test coverage for CorePlugin existent code

### DIFF
--- a/src/base/core_plugin/core_plugin.js
+++ b/src/base/core_plugin/core_plugin.js
@@ -1,6 +1,6 @@
-import { extend } from '../../utils'
-import BaseObject from '../base_object'
-import ErrorMixin from '../error_mixin'
+import { extend } from '@//utils'
+import BaseObject from '@/base/base_object'
+import ErrorMixin from '@/base/error_mixin'
 
 export default class CorePlugin extends BaseObject {
   get playerError() { return this.core.playerError }

--- a/src/base/core_plugin/core_plugin.test.js
+++ b/src/base/core_plugin/core_plugin.test.js
@@ -1,5 +1,6 @@
 import CorePlugin from './core_plugin'
 import ErrorMixin from '@/base/error_mixin'
+import Player from '@/components/player'
 
 describe('Core Plugin', () => {
   describe('#constructor', () => {
@@ -93,5 +94,28 @@ describe('Core Plugin', () => {
     const plugin = CorePlugin.extend({ name: 'test_plugin' })
 
     expect(plugin.prototype instanceof CorePlugin).toBeTruthy()
+  })
+
+  test('exposes interfaces for player scope', () => {
+    const pluginInterface = () => 'This is awesome!'
+
+    const Plugin = class MyPlugin extends CorePlugin {
+      getExternalInterface() {
+        return { pluginInterface }
+      }
+    }
+
+    const plugin = new Plugin({})
+    const player = new Player({})
+
+    player._coreFactory.setupExternalInterface(plugin)
+
+    expect(player.pluginInterface()).toEqual('This is awesome!')
+  })
+
+  test('has a default value for getExternalInterface method', () => {
+    const plugin = new CorePlugin({})
+
+    expect(plugin.getExternalInterface()).toEqual({})
   })
 })

--- a/src/base/core_plugin/core_plugin.test.js
+++ b/src/base/core_plugin/core_plugin.test.js
@@ -2,7 +2,7 @@ import CorePlugin from './core_plugin'
 
 describe('Core Plugin', () => {
   describe('#constructor', () => {
-    test('enables', () => {
+    test('enables the plugin', () => {
       const plugin = new CorePlugin({})
 
       expect(plugin.enabled).toBeTruthy()
@@ -22,7 +22,7 @@ describe('Core Plugin', () => {
     })
   })
 
-  test('disables', () => {
+  test('can be disabled after your creation', () => {
     const plugin = new CorePlugin({})
 
     plugin.disable()
@@ -39,7 +39,7 @@ describe('Core Plugin', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
-  test('doesnt stops listening when disable a disabled plugin', () => {
+  test('doesn\'t stops listening when disable a disabled plugin', () => {
     const plugin = new CorePlugin({})
     const spy = jest.spyOn(plugin, 'stopListening')
 

--- a/src/base/core_plugin/core_plugin.test.js
+++ b/src/base/core_plugin/core_plugin.test.js
@@ -1,8 +1,8 @@
 import CorePlugin from './core_plugin'
 
-describe('Core Plugin', function() {
+describe('Core Plugin', () => {
   describe('#constructor', () => {
-    test('enables', function() {
+    test('enables', () => {
       const plugin = new CorePlugin({})
 
       expect(plugin.enabled).toBeTruthy()

--- a/src/base/core_plugin/core_plugin.test.js
+++ b/src/base/core_plugin/core_plugin.test.js
@@ -30,6 +30,18 @@ describe('Core Plugin', () => {
     expect(plugin.enabled).toBeFalsy()
   })
 
+  test('can be enabled after your creation', () => {
+    const plugin = new CorePlugin({})
+
+    plugin.disable()
+
+    expect(plugin.enabled).toBeFalsy()
+
+    plugin.enable()
+
+    expect(plugin.enabled).toBeTruthy()
+  })
+
   test('stops listening when disable an enabled plugin', () => {
     const plugin = new CorePlugin({})
     const spy = jest.spyOn(plugin, 'stopListening')

--- a/src/base/core_plugin/core_plugin.test.js
+++ b/src/base/core_plugin/core_plugin.test.js
@@ -1,4 +1,5 @@
 import CorePlugin from './core_plugin'
+import ErrorMixin from '@/base/error_mixin'
 
 describe('Core Plugin', () => {
   describe('#constructor', () => {
@@ -40,6 +41,13 @@ describe('Core Plugin', () => {
     plugin.enable()
 
     expect(plugin.enabled).toBeTruthy()
+  })
+
+  test('receives createdError method from ErrorMixin', () => {
+    const plugin = new CorePlugin({})
+
+    expect(plugin.createError).not.toBeUndefined()
+    expect(plugin.createError).toEqual(ErrorMixin.createError)
   })
 
   test('stops listening when disable an enabled plugin', () => {

--- a/src/base/core_plugin/core_plugin.test.js
+++ b/src/base/core_plugin/core_plugin.test.js
@@ -88,4 +88,10 @@ describe('Core Plugin', () => {
 
     expect(spy).not.toHaveBeenCalled()
   })
+
+  test('can be created via extends method', () => {
+    const plugin = CorePlugin.extend({ name: 'test_plugin' })
+
+    expect(plugin.prototype instanceof CorePlugin).toBeTruthy()
+  })
 })


### PR DESCRIPTION
## Summary 

This PR adds tests for existent code on `core_plugin.js`.

## Changes

- Use path alias to import modules on `core_plugin.js`
- Create tests for `enable` method;
- Create tests for `ErrorMixin` assignment;
- Create tests for `extend` feature;
- Create tests for `external interface` feature;

## How to test

All changes in this PR should not impact any use of the Clappr.
