### PR TITLE
 Tests - Create tests for Loader existent code

### DIFF
--- a/src/components/loader/loader.js
+++ b/src/components/loader/loader.js
@@ -1,8 +1,8 @@
 // Copyright 2014 Globo.com Player authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-import Version from '../../utils/version'
-import Log from '../log'
+import Version from '@/utils/version'
+import Log from '@/components/log'
 
 const filterPluginsByType = (plugins, type) => {
   if (!plugins || !type) return {}

--- a/src/components/loader/loader.js
+++ b/src/components/loader/loader.js
@@ -240,8 +240,8 @@ export default (() => {
      * @param {Object} plugins the config object with all plugins
      */
     validateExternalPluginsType(plugins) {
-      const plugintypes = ['playback', 'container', 'core']
-      plugintypes.forEach((type) => {
+      const pluginTypes = ['playback', 'container', 'core']
+      pluginTypes.forEach((type) => {
         (plugins[type] || []).forEach((el) => {
           const errorMessage = 'external ' + el.type + ' plugin on ' + type + ' array'
           if (el.type !== type) throw new ReferenceError(errorMessage)

--- a/src/components/loader/loader.js
+++ b/src/components/loader/loader.js
@@ -91,7 +91,7 @@ export default (() => {
 
       let { playbacks } = registry
 
-      const previousEntryIdx = playbacks.findIndex((entry) => entry.name === playbackEntry.prototype.name)
+      const previousEntryIdx = playbacks.findIndex((entry) => entry.prototype.name === playbackEntry.prototype.name)
 
       if (previousEntryIdx >= 0) {
         const previousEntry = playbacks[previousEntryIdx]

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -5,12 +5,7 @@ import CorePlugin from '../../base/core_plugin'
 import ContainerPlugin from '../../base/container_plugin'
 import UIContainerPlugin from '../../base/ui_container_plugin'
 
-describe('Loader', function() {
-  let loader
-  beforeEach(() => {
-    loader = new Loader()
-  })
-
+describe('Loader', () => {
   test('starts with an empty plugin registry', () => {
     expect(Loader.registeredPlugins.core).toEqual({})
     expect(Loader.registeredPlugins.container).toEqual({})
@@ -116,6 +111,7 @@ describe('Loader', function() {
 
   describe('addExternalPlugins function', () => {
     test('extends the plugins array with the external ones', () => {
+      const loader = new Loader()
       const playbackPlugin = PlaybackPlugin.extend({ name: 'playbackPlugin' })
       playbackPlugin.canPlay = () => true
       const containerPlugin = ContainerPlugin.extend({ name: 'containerPlugin' })
@@ -138,6 +134,7 @@ describe('Loader', function() {
     })
 
     test('supports an array of plugins and group them by type', () => {
+      const loader = new Loader()
       const playbackPlugin = PlaybackPlugin.extend({ name: 'playbackPlugin' })
       const containerPlugin = ContainerPlugin.extend({ name: 'containerPlugin' })
       const corePlugin = CorePlugin.extend({ name: 'corePlugin' })
@@ -235,7 +232,10 @@ describe('Loader', function() {
     })
 
     describe('overriding plugins', () => {
+      let loader
+
       beforeEach(() => {
+        loader = new Loader()
         loader.containerPlugins = [
           ...loader.containerPlugins,
           ContainerPlugin.extend({ name: 'spinner' })
@@ -327,6 +327,8 @@ describe('Loader', function() {
 
   describe('validateExternalPluginsType function', () => {
     test('throws an exception if plugin type does not match where it\'s being added', () => {
+      const loader = new Loader()
+
       expect(() => { loader.validateExternalPluginsType({ core: [PlaybackPlugin] }) }).toThrow('external playback plugin on core array')
       expect(() => { loader.validateExternalPluginsType({ container: [PlaybackPlugin] }) }).toThrow('external playback plugin on container array')
 

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -65,6 +65,56 @@ describe('Loader', () => {
     })
   })
 
+  describe('unregisterPlugin', () => {
+    let corePlugin, containerPlugin
+    beforeEach(() => {
+      corePlugin = CorePlugin.extend({ name: 'core-plugin' })
+      containerPlugin = ContainerPlugin.extend({ name: 'container-plugin' })
+    })
+
+    afterEach(() => {
+      Loader.clearPlugins()
+    })
+
+    test('rejects invalid plugin parameter', () => {
+      Loader.registerPlugin(corePlugin)
+      const unregistered = Loader.unregisterPlugin(undefined)
+
+      expect(unregistered).toBeFalsy()
+      expect(Loader.registeredPlugins.core['core-plugin']).toEqual(corePlugin)
+    })
+
+    test('rejects unregistered plugin parameter', () => {
+      Loader.registerPlugin(corePlugin)
+      const unregistered = Loader.unregisterPlugin('unregistered-plugin')
+
+      expect(unregistered).toBeFalsy()
+      expect(Loader.registeredPlugins.core['core-plugin']).toEqual(corePlugin)
+    })
+
+    test('remove a plugin from the corresponding scope registry', () => {
+      let registered = Loader.registerPlugin(corePlugin)
+
+      expect(registered).toBeTruthy()
+      expect(Loader.registeredPlugins.core['core-plugin']).toEqual(corePlugin)
+
+      registered = Loader.registerPlugin(containerPlugin)
+
+      expect(registered).toBeTruthy()
+
+      let unregistered = Loader.unregisterPlugin('core-plugin')
+
+      expect(unregistered).toBeTruthy()
+      expect(Loader.registeredPlugins.core).toEqual({})
+      expect(Loader.registeredPlugins.container['container-plugin']).toEqual(containerPlugin)
+
+      unregistered = Loader.unregisterPlugin('container-plugin')
+
+      expect(unregistered).toBeTruthy()
+      expect(Loader.registeredPlugins.container).toEqual({})
+    })
+  })
+
   describe('registerPlayback', () => {
     let playback
     beforeEach(() => {

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -1,9 +1,9 @@
 import Loader from './loader'
 
-import PlaybackPlugin from '../../base/playback'
-import CorePlugin from '../../base/core_plugin'
-import ContainerPlugin from '../../base/container_plugin'
-import UIContainerPlugin from '../../base/ui_container_plugin'
+import PlaybackPlugin from '@/base/playback'
+import CorePlugin from '@/base/core_plugin'
+import ContainerPlugin from '@/base/container_plugin'
+import UIContainerPlugin from '@/base/ui_container_plugin'
 
 describe('Loader', () => {
   test('starts with an empty plugin registry', () => {

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -159,6 +159,46 @@ describe('Loader', () => {
     })
   })
 
+  describe('unregisterPlayback', () => {
+    let playback
+    beforeEach(() => {
+      playback = PlaybackPlugin.extend({ name: 'some-playback' })
+    })
+
+    afterEach(() => {
+      Loader.clearPlaybacks()
+    })
+
+    test('rejects invalid plugin parameter', () => {
+      Loader.registerPlayback(playback)
+      const unregistered = Loader.unregisterPlayback(undefined)
+
+      expect(unregistered).toBeFalsy()
+      expect(Loader.registeredPlaybacks[0]).toEqual(playback)
+    })
+
+    test('rejects unregistered playback parameter', () => {
+      Loader.registerPlayback(playback)
+      const unregistered = Loader.unregisterPlayback('unregistered-playback')
+
+      expect(unregistered).toBeFalsy()
+      expect(Loader.registeredPlaybacks[0]).toEqual(playback)
+    })
+
+    test('removes a playback', () => {
+      const registered = Loader.registerPlayback(playback)
+
+      expect(registered).toBeTruthy()
+      expect(Loader.registeredPlaybacks[0]).toEqual(playback)
+
+
+      const unregistered = Loader.unregisterPlayback('some-playback')
+
+      expect(unregistered).toBeTruthy()
+      expect(Loader.registeredPlaybacks).toEqual([])
+    })
+  })
+
   describe('addExternalPlugins function', () => {
     test('extends the plugins array with the external ones', () => {
       const loader = new Loader()

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -82,7 +82,7 @@ describe('Loader', () => {
       expect(Loader.registeredPlaybacks).toEqual([])
     })
 
-    test('rejects a plugin without a valid name', () => {
+    test('rejects a playback without a valid name', () => {
       const invalidPlayback = PlaybackPlugin.extend({ name: '' })
       const registered = Loader.registerPlayback(invalidPlayback)
 
@@ -100,7 +100,7 @@ describe('Loader', () => {
 
     test('overrides a playback with the same name', () => {
       const otherPlayback = PlaybackPlugin.extend({ name: 'some-playback' })
-      Loader.registerPlugin(playback)
+      Loader.registerPlayback(playback)
       const registered = Loader.registerPlayback(otherPlayback)
 
       expect(registered).toBeTruthy()

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -15,6 +15,46 @@ describe('Loader', () => {
     expect(Loader.registeredPlaybacks).toEqual([])
   })
 
+  describe('checkVersionSupport function', () => {
+    let corePlugin, containerPlugin
+    beforeEach(() => {
+      corePlugin = CorePlugin.extend({ name: 'core-plugin', supportedVersion: { min: '0.4.0' } })
+      containerPlugin = ContainerPlugin.extend({ name: 'container-plugin', supportedVersion: { min: '0.4.0', max: '9.9.9' } })
+    })
+
+    afterEach(() => {
+      Loader.clearPlugins()
+    })
+
+    test('inform missing supportedVersion config', () => {
+      const plugin = CorePlugin.extend({ name: 'core-plugin', supportedVersion: {} })
+
+      const hasPluginMinimumSupportedVersion = Loader.checkVersionSupport(plugin)
+
+      expect(hasPluginMinimumSupportedVersion).toBeFalsy()
+    })
+
+    test('uses min version to stipulate the not informed max version', () => {
+      const isClapprVersionSupported = Loader.checkVersionSupport(corePlugin)
+
+      expect(isClapprVersionSupported).toBeTruthy()
+    })
+
+    test('inform the version incompatibility', () => {
+      const plugin = CorePlugin.extend({ name: 'core-plugin', supportedVersion: { min: '0.4.0', max: '0.4.1' } })
+
+      const hasPluginMinimumSupportedVersion = Loader.checkVersionSupport(plugin)
+
+      expect(hasPluginMinimumSupportedVersion).toBeFalsy()
+    })
+
+    test('inform the version compatibility', () => {
+      const hasPluginMinimumSupportedVersion = Loader.checkVersionSupport(containerPlugin)
+
+      expect(hasPluginMinimumSupportedVersion).toBeTruthy()
+    })
+  })
+
   describe('registerPlugin', () => {
     let corePlugin, containerPlugin
     beforeEach(() => {

--- a/src/components/loader/loader.test.js
+++ b/src/components/loader/loader.test.js
@@ -340,6 +340,20 @@ describe('Loader', () => {
 
       expect(() => { loader.validateExternalPluginsType({ core: [UIContainerPlugin] }) }).toThrow('external container plugin on core array')
       expect(() => { loader.validateExternalPluginsType({ playback: [UIContainerPlugin] }) }).toThrow('external container plugin on playback array')
+
+      const core = CorePlugin.extend({ name: 'core-plugin' })
+      const container = ContainerPlugin.extend({ name: 'container-plugin' })
+      const playback = PlaybackPlugin.extend({ name: 'some-playback' })
+
+      const loader1 = new Loader({
+        core: [core],
+        container: [container],
+        playback: [playback],
+      })
+
+      expect(loader1.corePlugins[0]).toEqual(core)
+      expect(loader1.containerPlugins[0]).toEqual(container)
+      expect(loader1.playbackPlugins[0]).toEqual(playback)
     })
   })
 })


### PR DESCRIPTION
## Summary 

This PR adds tests for existent code on the `loader.js`. Also, fix one problem in the overwrite flow on the `registerPlayback` static method.
## Changes

- Use path alias to import modules on `loader.js`/`loader.test.js` files;
- Fix overwrite feature on `registerPlayback` method;
- Improve existent tests messages;
- Update existent tests for `validateExternalPluginsType` method;
- Create tests for `checkVersionSupport` method;
- Create tests for `unregisterPlugin` method;
- Create tests for `unregisterPlayback` method;

## How to test

All changes in this PR should not impact any use of the Clappr.