### PR TITLE
 Tests - Create tests for PlayerError existent code

### DIFF
--- a/src/components/error/error.js
+++ b/src/components/error/error.js
@@ -1,6 +1,6 @@
-import Events from '../../base/events'
-import BaseObject from '../../base/base_object'
-import Log from '../log'
+import Events from '@/base/events'
+import BaseObject from '@/base/base_object'
+import Log from '@/components/log'
 
 /**
  * The PlayerError is responsible to receive and propagate errors.

--- a/src/components/error/error.js
+++ b/src/components/error/error.js
@@ -24,7 +24,7 @@ class PlayerError extends BaseObject {
     }
   }
 
-  constructor(options={}, core) {
+  constructor(options = {}, core) {
     super(options)
     this.core = core
   }

--- a/src/components/error/error.test.js
+++ b/src/components/error/error.test.js
@@ -16,6 +16,19 @@ describe('PlayerError', function() {
     }
   })
 
+  test('has default value to options', () => {
+    const playerError = new PlayerError(undefined, new Core({}))
+
+    expect(playerError.options).toEqual({})
+  })
+
+  test('have reference to access received options on your construction', () => {
+    const options = { testOption: 'some_option' }
+    const playerError = new PlayerError(options, new Core(options))
+
+    expect(playerError.options).toEqual(options)
+  })
+
   describe('when error method is called', () => {
     test('triggers ERROR event', () => {
       jest.spyOn(this.core, 'trigger')

--- a/src/components/error/error.test.js
+++ b/src/components/error/error.test.js
@@ -1,6 +1,6 @@
-import Core from '../core'
+import Core from '@/components/core'
 import PlayerError from './error'
-import Events from '../../base/events'
+import Events from '@/base/events'
 
 describe('PlayerError', function() {
   beforeEach(() => {


### PR DESCRIPTION
## Summary 

This PR adds tests for existent code on `error.js`.

## Changes

- Use path alias to import modules on `error.js`/`error.test.js` files;
- Add more readability to `constructor` declaration;
- Add more tests for `constructor`;

## How to test

All changes in this PR should not impact any use of the Clappr.
