### PR TITLE
 Core - Handle fullscreen unexpected behavior

### DIFF
--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -319,7 +319,16 @@ export default class Core extends UIObject {
     } else {
       const fullscreenEl = Browser.isiOS ? this.activePlayback && this.activePlayback.el : this.el
       if (!fullscreenEl) return
-      Fullscreen.requestFullscreen(fullscreenEl)
+
+      (Browser.isSafari || Browser.isiOS) // Safari doesn't return a promise like the other browsers. See more in https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen
+        ? Fullscreen.requestFullscreen(fullscreenEl)
+        : Fullscreen.requestFullscreen(fullscreenEl).then(
+          _ => _,
+          error => setTimeout(() => {  // fixes the issue https://github.com/clappr/clappr/issues/1860
+            if (!this.isFullscreen()) throw new ReferenceError(error)
+          }, 600),
+        )
+
       !Browser.isiOS && this.$el.addClass('fullscreen')
     }
   }

--- a/src/components/core/core.test.js
+++ b/src/components/core/core.test.js
@@ -113,12 +113,15 @@ describe('Core', function() {
 
       describe('and is not an iOS Browser', () => {
         test('calls Fullscreen.requestFullscreen with core element', () => {
+          this.core.el.requestFullscreen = () => new Promise((resolve, reject) => this.core.el ? resolve() : reject())
           this.core.toggleFullscreen()
 
           expect(Fullscreen.requestFullscreen).toHaveBeenCalledWith(this.core.el)
+          delete this.core.el.requestFullscreen
         })
 
         test('adds a class "fullscreen" to core element', () => {
+          this.core.el.requestFullscreen = () => new Promise((resolve, reject) => this.core.el ? resolve() : reject())
           jest.spyOn(this.core.$el, 'addClass')
           jest.spyOn(this.core, 'isFullscreen').mockReturnValue(false)
 
@@ -127,6 +130,7 @@ describe('Core', function() {
           this.core.toggleFullscreen()
 
           expect(this.core.$el.addClass).toHaveBeenCalledWith('fullscreen')
+          delete this.core.el.requestFullscreen
         })
       })
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -74,19 +74,20 @@ export const Fullscreen = {
       document.msFullscreenElement
   },
   requestFullscreen: function(el) {
-    if (el.requestFullscreen)
-      el.requestFullscreen()
-    else if (el.webkitRequestFullscreen)
+    if (el.requestFullscreen) {
+      return el.requestFullscreen()
+    } else if (el.webkitRequestFullscreen) {
+      if (typeof el.then === 'function') return el.webkitRequestFullscreen()
       el.webkitRequestFullscreen()
-    else if (el.mozRequestFullScreen)
-      el.mozRequestFullScreen()
-    else if (el.msRequestFullscreen)
-      el.msRequestFullscreen()
-    else if (el.querySelector && el.querySelector('video') && el.querySelector('video').webkitEnterFullScreen)
+    } else if (el.mozRequestFullScreen) {
+      return el.mozRequestFullScreen()
+    } else if (el.msRequestFullscreen) {
+      return el.msRequestFullscreen()
+    } else if (el.querySelector && el.querySelector('video') && el.querySelector('video').webkitEnterFullScreen) {
       el.querySelector('video').webkitEnterFullScreen()
-    else if (el.webkitEnterFullScreen)
+    } else if (el.webkitEnterFullScreen) {
       el.webkitEnterFullScreen()
-
+    }
   },
   cancelFullscreen: function(el=document) {
     if (el.exitFullscreen)


### PR DESCRIPTION
## Summary 

At some browsers, the `requestFullscreen` method returns an error even when the fullscreen mode is activated successfully.

This PR adds a delay to check for reject response of `requestFullscreen` method if it's a promise and only prints the error if the fullscreen mode has not activated.

## Changes

- `utils.js`:
  - Returns the response of `requestFullscreen` method if is a promise;
- `core.js`:
  - Handles the promise on browsers that support this response;
  - Handles the `reject` delaying the response;
  - Checks if the element is already in fullscreen mode before throws the error;

## How to test

This problem only appears on the https://github.com/clappr/clappr or https://github.com/clappr/clappr-plugins projects. So, generate one build of `@clappr/core` and add inside those projects or use the `yarn link` approach to test this branch on one of these projects. After that:

- Play one media;
- Open the `console` on developer tools;
- Do double-click on the player;
  - The player should enter on fullscreen mode.
  - No error should be print on the `console`.