### PR TITLE
Tests - Create tests for ContainerFactory existent code

### DIFF
--- a/src/components/container_factory/container_factory.js
+++ b/src/components/container_factory/container_factory.js
@@ -36,15 +36,15 @@ export default class ContainerFactory extends BaseObject {
   }
 
   createContainer(source) {
-    let resolvedSource = null,
-      mimeType = this.options.mimeType
+    let resolvedSource = null
+    let mimeType = this.options.mimeType
+
     if (typeof source === 'object') {
       resolvedSource = source.source.toString()
-      if (source.mimeType)
-        mimeType = source.mimeType
-
-    } else { resolvedSource = source.toString() }
-
+      if (source.mimeType) mimeType = source.mimeType
+    } else {
+      resolvedSource = source.toString()
+    }
 
     if (resolvedSource.match(/^\/\//)) resolvedSource = window.location.protocol + resolvedSource
 

--- a/src/components/container_factory/container_factory.js
+++ b/src/components/container_factory/container_factory.js
@@ -6,11 +6,11 @@
  * The ContainerFactory is responsible for manage playback bootstrap and create containers.
  */
 
-import BaseObject from '../../base/base_object'
-import Events from '../../base/events'
-import Container from '../container'
 import $ from 'clappr-zepto'
-import Playback from '../../base/playback'
+import BaseObject from '@/base/base_object'
+import Events from '@/base/events'
+import Container from '@/components/container'
+import Playback from '@/base/playback'
 
 export default class ContainerFactory extends BaseObject {
   get options() { return this._options }

--- a/src/components/container_factory/container_factory.js
+++ b/src/components/container_factory/container_factory.js
@@ -48,16 +48,14 @@ export default class ContainerFactory extends BaseObject {
 
     if (resolvedSource.match(/^\/\//)) resolvedSource = window.location.protocol + resolvedSource
 
-    let options = $.extend({}, this.options, {
-      src: resolvedSource,
-      mimeType: mimeType
-    })
+    let options = { ...this.options, src: resolvedSource, mimeType: mimeType }
+
     const playbackPlugin = this.findPlaybackPlugin(resolvedSource, mimeType)
 
     // Fallback to empty playback object until we sort out unsupported sources error without NoOp playback
     const playback = playbackPlugin ? new playbackPlugin(options, this._i18n, this.playerError) : new Playback()
 
-    options = $.extend({}, options, { playback: playback })
+    options = { ...options, playback: playback }
 
     const container = new Container(options, this._i18n, this.playerError)
     const defer = $.Deferred()

--- a/src/components/container_factory/container_factory.test.js
+++ b/src/components/container_factory/container_factory.test.js
@@ -1,6 +1,7 @@
 import ContainerFactory from './container_factory'
 import Loader from '@/components/loader'
 import ContainerPlugin from '@/base/container_plugin'
+import Playback from '@/base/playback'
 
 describe('ContainerFactory', function() {
   beforeEach(() => {
@@ -39,5 +40,54 @@ describe('ContainerFactory', function() {
     const pluginInstance = container.getPlugin('test_plugin')
 
     expect(pluginInstance.container).toEqual(container)
+  })
+
+  describe('createContainer method', () => {
+    test('creates a container for a given source', () => {
+      const source = 'http://some.url/for/video.mp4'
+      const containerFactory =  new ContainerFactory({}, new Loader(), {})
+      const container = containerFactory.createContainer(source)
+
+      expect(container.options.src).toEqual(source)
+    })
+
+    test('creates a playback instance based on existent playback plugins and a given source', () => {
+      class CustomPlayback extends Playback {
+        get name() { return 'custom-playback' }
+        get supportedVersion() { return { min: VERSION } }
+      }
+      CustomPlayback.canPlay = () => true
+      Loader.registerPlayback(CustomPlayback)
+
+      const source = 'http://some.url/for/video.mp4'
+      const containerFactory =  new ContainerFactory({}, new Loader(), {})
+      const container = containerFactory.createContainer(source)
+
+      expect(container.playback.name).toEqual('custom-playback')
+    })
+
+    test('creates a container for a given set of options that includes a source', () => {
+      const options = { source: 'http://some.url/for/video.mp4' }
+      const containerFactory =  new ContainerFactory({}, new Loader(), {})
+      const container = containerFactory.createContainer(options)
+
+      expect(container.options.src).toEqual(options.source)
+    })
+
+    test('creates a container for a given set of options that includes a source and a mimeType', () => {
+      const options = { source: 'http://some.url/for/video', mimeType: 'mp4' }
+      const containerFactory =  new ContainerFactory({}, new Loader(), {})
+      const container = containerFactory.createContainer(options)
+
+      expect(container.options.src).toEqual(options.source)
+    })
+
+    test('uses current domain protocol to set source on the container instance', () => {
+      const source = '//some.url/for/video.mp4'
+      const containerFactory =  new ContainerFactory({}, new Loader(), {})
+      const container = containerFactory.createContainer(source)
+
+      expect(container.options.src).toEqual(`http:${source}`)
+    })
   })
 })

--- a/src/components/container_factory/container_factory.test.js
+++ b/src/components/container_factory/container_factory.test.js
@@ -1,4 +1,6 @@
 import ContainerFactory from './container_factory'
+import Loader from '@/components/loader'
+import ContainerPlugin from '@/base/container_plugin'
 
 describe('ContainerFactory', function() {
   beforeEach(() => {
@@ -23,5 +25,19 @@ describe('ContainerFactory', function() {
     const newSource = 'http://some.url/for/video.m3u8'
     this.containerFactory.options = { ...this.options,  source: newSource }
     expect(this.containerFactory.options.source).toEqual(newSource)
+  })
+
+  test('addContainerPlugins method creates registered container plugins for a given container', () => {
+    const plugin = ContainerPlugin.extend({ name: 'test_plugin' })
+    Loader.registerPlugin(plugin)
+
+    const source = 'http://some.url/for/video.mp4'
+    const containerFactory =  new ContainerFactory({}, new Loader(), {})
+    const container = containerFactory.createContainer(source)
+    expect(container.getPlugin('test_plugin')).not.toBeUndefined()
+
+    const pluginInstance = container.getPlugin('test_plugin')
+
+    expect(pluginInstance.container).toEqual(container)
   })
 })

--- a/src/components/container_factory/container_factory.test.js
+++ b/src/components/container_factory/container_factory.test.js
@@ -90,4 +90,17 @@ describe('ContainerFactory', function() {
       expect(container.options.src).toEqual(`http:${source}`)
     })
   })
+
+  describe('createContainers method', () => {
+    test('creates a container for each source existent in sources array option', (done) => {
+      const sources = ['http://some.url/for/video.mp4', 'http://another.url/for/video.mp4']
+      const containerFactory =  new ContainerFactory({ sources }, new Loader(), {})
+      containerFactory.createContainers().then(containers => {
+        expect(containers.length).toEqual(2)
+        expect(containers[0].options.src).toEqual(sources[0])
+        expect(containers[1].options.src).toEqual(sources[1])
+        done()
+      })
+    })
+  })
 })

--- a/src/components/container_factory/container_factory.test.js
+++ b/src/components/container_factory/container_factory.test.js
@@ -1,7 +1,5 @@
 import ContainerFactory from './container_factory'
 
-import $ from 'clappr-zepto'
-
 describe('ContainerFactory', function() {
   beforeEach(() => {
     this.options = {
@@ -23,7 +21,7 @@ describe('ContainerFactory', function() {
     expect(this.containerFactory.options.source).toEqual(this.options.source)
     expect(this.containerFactory.options.autoPlay).toEqual(this.options.autoPlay)
     const newSource = 'http://some.url/for/video.m3u8'
-    this.containerFactory.options = $.extend({}, this.options, { source: newSource })
+    this.containerFactory.options = { ...this.options,  source: newSource }
     expect(this.containerFactory.options.source).toEqual(newSource)
   })
 })


### PR DESCRIPTION
## Summary 

This PR adds tests for existent code on `container_factory.js`. Also, refactor old code to use current JS features.

## Changes

- Use path alias to import modules on `container_factory.js`/`container_factory.test.js` files;
- Add more readability to `createContainer` method;
- Use spread operator instead Zepto `extends`;
- Create tests for `createContainer` method;
- Create tests for `createContainers` method;
- Create tests for `addContainerPlugins` method;

## How to test

All changes in this PR should not impact any use of the Clappr.
