### PR TITLE
Container - Propagate seek event from playback

### DIFF
--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -173,6 +173,7 @@ export default class Container extends UIObject {
     this.listenTo(this.playback, Events.PLAYBACK_DVR, this.playbackDvrStateChanged)
     this.listenTo(this.playback, Events.PLAYBACK_MEDIACONTROL_DISABLE, this.disableMediaControl)
     this.listenTo(this.playback, Events.PLAYBACK_MEDIACONTROL_ENABLE, this.enableMediaControl)
+    this.listenTo(this.playback, Events.PLAYBACK_SEEK, this.onSeek)
     this.listenTo(this.playback, Events.PLAYBACK_SEEKED, this.onSeeked)
     this.listenTo(this.playback, Events.PLAYBACK_ENDED, this.onEnded)
     this.listenTo(this.playback, Events.PLAYBACK_PLAY, this.playing)
@@ -372,8 +373,11 @@ export default class Container extends UIObject {
   }
 
   seek(time) {
-    this.trigger(Events.CONTAINER_SEEK, time, this.name)
     this.playback.seek(time)
+  }
+
+  onSeek(time) {
+    this.trigger(Events.CONTAINER_SEEK, time, this.name)
   }
 
   onSeeked() {

--- a/src/components/container/container.test.js
+++ b/src/components/container/container.test.js
@@ -74,6 +74,21 @@ describe('Container', function() {
     expect(this.container.timeUpdated).toHaveBeenCalledWith({ current: 2, total: 40 })
   })
 
+  test('listens to playback:seek event', (done) => {
+    let playback = new HTML5Playback({ src: '/base/test/fixtures/SampleVideo_360x240_1mb.mp4' })
+    let container = new Container({ playback: playback })
+    let callback = jest.fn()
+
+    container.bindEvents()
+    container.on(Events.CONTAINER_SEEK, callback)
+    container.on(Events.CONTAINER_SEEK, () => {
+      expect(callback).toHaveBeenCalled()
+      done()
+    })
+
+    playback.el.dispatchEvent(new Event('seeking'))
+  })
+
   test('listens to playback:seeked event', (done) => {
     let playback = new HTML5Playback({ src: '/base/test/fixtures/SampleVideo_360x240_1mb.mp4' })
     let container = new Container({ playback: playback })

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -425,8 +425,8 @@ export default class HTML5Video extends Playback {
   }
 
   _onSeeking() {
+    this.trigger(Events.PLAYBACK_SEEK, this.getCurrentTime())
     this._handleBufferingEvents()
-    this.trigger(Events.PLAYBACK_SEEK)
   }
 
   _onSeeked() {


### PR DESCRIPTION
In some cases, the playback can trigger a `PLAYBACK_SEEK` event via `seeking` event from `html5`.
In this case, the container was not notifying the seek.

The `PLAYBACK_SEEK` in `html5` now notifies the event with the playback `current time` and, also, before calling `buffering` to keep the order of seek -> buffering events.