### PR TITLE
Tests - Create tests for CoreFactory existent code

### DIFF
--- a/src/components/core_factory/core_factory.js
+++ b/src/components/core_factory/core_factory.js
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import BaseObject from '../../base/base_object'
-import Core from '../core'
+import BaseObject from '@/base/base_object'
+import Core from '@/components/core'
 
 /**
  * The Core Factory is responsible for instantiate the core and it's plugins.

--- a/src/components/core_factory/core_factory.js
+++ b/src/components/core_factory/core_factory.js
@@ -22,9 +22,8 @@ export default class CoreFactory extends BaseObject {
    * @param {Player} player the player object
    */
   constructor(player) {
-    super()
+    super(player.options)
     this.player = player
-    this._options = player.options
   }
 
   /**

--- a/src/components/core_factory/core_factory.test.js
+++ b/src/components/core_factory/core_factory.test.js
@@ -1,5 +1,6 @@
 import CoreFactory from './core_factory'
 import Core from '@/components/core'
+import CorePlugin from '@/base/core_plugin'
 import Player from '@/components/player'
 
 describe('CoreFactory', () => {
@@ -38,6 +39,32 @@ describe('CoreFactory', () => {
 
     test('trigger container creation for the core instance', () => {
       expect(factory.core.activeContainer).not.toBeUndefined()
+    })
+
+    test('returns the internal core instance', () => {
+      expect(coreInstance).toEqual(factory.core)
+      expect(coreInstance instanceof Core).toBeTruthy()
+    })
+  })
+
+  describe('addCorePlugins method', () => {
+    const factory = new CoreFactory(barePlayer)
+    const plugin = CorePlugin.extend({ name: 'test_plugin' })
+    factory.loader.corePlugins = [plugin]
+    factory.create()
+    jest.spyOn(factory, 'setupExternalInterface')
+    const coreInstance = factory.addCorePlugins()
+
+    test('adds registered core plugins into the core instance', () => {
+      expect(factory.core.getPlugin('test_plugin')).not.toBeUndefined()
+
+      const pluginInstance = factory.core.getPlugin('test_plugin')
+
+      expect(pluginInstance.core).toEqual(factory.core)
+    })
+
+    test('calls setupExternalInterface method for each plugin added', () => {
+      expect(factory.setupExternalInterface).toHaveBeenCalledTimes(1)
     })
 
     test('returns the internal core instance', () => {

--- a/src/components/core_factory/core_factory.test.js
+++ b/src/components/core_factory/core_factory.test.js
@@ -9,4 +9,12 @@ describe('CoreFactory', () => {
   test('creates player reference on constructor', () => {
     expect(bareFactory.player).toEqual(barePlayer)
   })
+
+  test('have a getter called loader', () => {
+    expect(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(bareFactory), 'loader').get).toBeTruthy()
+  })
+
+  test('loader getter returns current player loader reference', () => {
+    expect(bareFactory.loader).toEqual(barePlayer.loader)
+  })
 })

--- a/src/components/core_factory/core_factory.test.js
+++ b/src/components/core_factory/core_factory.test.js
@@ -1,0 +1,12 @@
+import CoreFactory from './core_factory'
+import Player from '@/components/player'
+
+describe('CoreFactory', () => {
+  const bareOptions = { source: 'http://some.url/for/video.mp4' }
+  const barePlayer = new Player(bareOptions)
+  const bareFactory = new CoreFactory(barePlayer)
+
+  test('creates player reference on constructor', () => {
+    expect(bareFactory.player).toEqual(barePlayer)
+  })
+})

--- a/src/components/core_factory/core_factory.test.js
+++ b/src/components/core_factory/core_factory.test.js
@@ -1,4 +1,5 @@
 import CoreFactory from './core_factory'
+import Core from '@/components/core'
 import Player from '@/components/player'
 
 describe('CoreFactory', () => {
@@ -16,5 +17,32 @@ describe('CoreFactory', () => {
 
   test('loader getter returns current player loader reference', () => {
     expect(bareFactory.loader).toEqual(barePlayer.loader)
+  })
+
+  describe('create method', () => {
+    const factory = new CoreFactory(barePlayer)
+    jest.spyOn(factory, 'addCorePlugins')
+    const coreInstance = factory.create()
+
+    test('sets a loader instance into options reference', () => {
+      expect(factory.options.loader).toEqual(barePlayer.loader)
+    })
+
+    test('sets a core instance into internal reference', () => {
+      expect(factory.core instanceof Core).toBeTruthy()
+    })
+
+    test('calls addCorePlugins method', () => {
+      expect(factory.addCorePlugins).toHaveBeenCalledTimes(1)
+    })
+
+    test('trigger container creation for the core instance', () => {
+      expect(factory.core.activeContainer).not.toBeUndefined()
+    })
+
+    test('returns the internal core instance', () => {
+      expect(coreInstance).toEqual(factory.core)
+      expect(coreInstance instanceof Core).toBeTruthy()
+    })
   })
 })

--- a/src/components/core_factory/core_factory.test.js
+++ b/src/components/core_factory/core_factory.test.js
@@ -72,4 +72,30 @@ describe('CoreFactory', () => {
       expect(coreInstance instanceof Core).toBeTruthy()
     })
   })
+
+  describe('setupExternalInterface method', () => {
+    class TestPlugin extends CorePlugin {
+      get name() { return 'test_plugin' }
+      constructor(core) {
+        super(core)
+        this.message = ''
+      }
+      addMessage(message) { this.message = message }
+      getExternalInterface() { return { addMessage: message => this.addMessage(message) } }
+    }
+
+    const player = new Player(bareOptions)
+    const factory = new CoreFactory(player)
+    factory.loader.corePlugins = [TestPlugin]
+    factory.create()
+    factory.setupExternalInterface(factory.core.getPlugin('test_plugin'))
+
+    test('binds registered methods in core plugins on Player component ', () => {
+      expect(player.addMessage).not.toBeUndefined()
+
+      player.addMessage('My awesome test!')
+
+      expect(factory.core.getPlugin('test_plugin').message).toEqual('My awesome test!')
+    })
+  })
 })


### PR DESCRIPTION
## Summary 

This PR adds tests for existent code on `core_factory.js`. Also, one refactoring on the `constructor` code to remove unnecessary operation.

## Changes

-  Use `src` path alias to import modules on `core_factory.js` file;
- Send `player.options` on `super()` call instead add options manually via `this_options` reference;
- Create tests for `constructor`;
- Create tests for `loader` getter
- Create tests for `create` method;
- Create tests for `addCorePlugins` method;
- Create tests for `setupExternalInterface` method;

## How to test

All changes in this PR should not impact any use of the Clappr.
