### PR TITLE
Player - Fix initial options merge

### DIFF
--- a/src/base/playback/playback.js
+++ b/src/base/playback/playback.js
@@ -224,7 +224,7 @@ export default class Playback extends UIObject {
    * @param {Object} options all the options to change in form of a javascript object
    */
   configure(options) {
-    this._options = $.extend(this._options, options)
+    this._options = $.extend(true, this._options, options)
   }
 
   /**

--- a/src/base/ui_object/ui_object.js
+++ b/src/base/ui_object/ui_object.js
@@ -190,7 +190,7 @@ export default class UIObject extends BaseObject {
    */
   _ensureElement() {
     if (!this.el) {
-      const attrs = $.extend({}, this.attributes)
+      const attrs = $.extend(true, {}, this.attributes)
       if (this.id) attrs.id = this.id
       if (this.className) attrs['class'] = this.className
       const $el = $(DomRecycler.create(this.tagName)).attr(attrs)

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -122,7 +122,7 @@ export default class Container extends UIObject {
     this.volume = 100
     this.playback = options.playback
     this.playerError = playerError
-    this.settings = $.extend({}, this.playback.settings)
+    this.settings = $.extend(true, {}, this.playback.settings)
     this.isReady = false
     this.mediaControlDisabled = false
     this.plugins = [this.playback]
@@ -510,7 +510,7 @@ export default class Container extends UIObject {
    * @param {Object} options all the options to change in form of a javascript object
    */
   configure(options) {
-    this._options = $.extend(this._options, options)
+    this._options = $.extend(true, this._options, options)
     this.updateStyle()
     this.playback.configure(this.options)
     this.trigger(Events.CONTAINER_OPTIONS_CHANGE)

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -220,7 +220,7 @@ export default class Core extends UIObject {
     sources = sources && sources.constructor === Array ? sources : [sources]
     this.options.sources = sources
     this.containers.forEach((container) => container.destroy())
-    this.containerFactory.options = $.extend(this.options, { sources })
+    this.containerFactory.options = $.extend(true, this.options, { sources })
     this.prepareContainers()
   }
 
@@ -349,7 +349,7 @@ export default class Core extends UIObject {
    * @param {Object} options all the options to change in form of a javascript object
    */
   configure(options) {
-    this._options = $.extend(this._options, options)
+    this._options = $.extend(true, this._options, options)
     this.configureDomRecycler()
 
     const sources = options.source || options.sources

--- a/src/components/player/player.js
+++ b/src/components/player/player.js
@@ -239,7 +239,7 @@ export default class Player extends BaseObject {
       includeResetStyle: true,
       playback: playbackDefaultOptions
     }
-    this._options = $.extend(defaultOptions, options)
+    this._options = $.extend(true, defaultOptions, options)
     this.options.sources = this._normalizeSources(options)
     if (!this.options.chromeless) {
       // "allowUserInteraction" cannot be false if not in chromeless mode.

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -139,7 +139,7 @@ export default class HTML5Video extends Playback {
 
     }
 
-    $.extend(this.el, {
+    $.extend(true, this.el, {
       muted: this.options.mute,
       defaultMuted: this.options.mute,
       loop: this.options.loop,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -289,7 +289,7 @@ export function canAutoPlayMedia(cb, options) {
 // Simple element factory with video recycle feature.
 export class DomRecycler {
   static configure(options) {
-    this.options = $.extend(this.options, options)
+    this.options = $.extend(true, this.options, options)
   }
 
   static create(name) {


### PR DESCRIPTION
## Summary

The `defaultOptions.playback` being overwritten when the received options on Clappr init have the `playback` options too. The expected behavior is the merge between those two options.

This PR applies the expected behavior using the Zepto `$.extend()` method with the option for a [deep merge approach](https://zeptojs.com/#$.extend).

## Changes

* Applies the deep merge config on every `$.extend` call;

## How to test

* Play one media;
* Print the value of `player.options.playback` on developr tools console tab;
  * The object should contain the property `recycleVideo: true` and `controls: true`.

## A picture tells a thousand words

### Before this PR
![Screen Shot 2020-11-01 at 02 05 02](https://user-images.githubusercontent.com/5631063/97810297-a587c800-1c51-11eb-9b81-4811208c0f76.png)

### After this PR
![Screen Shot 2020-11-01 at 02 04 21](https://user-images.githubusercontent.com/5631063/97810304-afa9c680-1c51-11eb-8541-a6ee9d0d4776.png)
