### PR TITLE
fix: allow video to restart when ended

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -274,12 +274,13 @@ export default class HTML5Video extends Playback {
   // On mobile device, HTML5 video element "retains" user action consent if
   // load() method is called. See Player.consent().
   consent(cb) {
-    if (this.isPlaying()) {
+    if (this.isPlaying() || this.el._consented) {
       super.consent(cb)
     } else {
       let eventHandler = () => {
         this.el.removeEventListener('loadedmetadata', eventHandler, false)
         this.el.removeEventListener('error', eventHandler, false)
+        this.el._consented = true // Flag to call load() only once
         super.consent(cb)
       }
 


### PR DESCRIPTION
A small regression has been introduced in Clappr core since version 0.4.8 preventing video to restart after it ended.
It is due to "synchonous" call of consent() method in poster plugin. (this was discuted [here](https://github.com/clappr/clappr-plugins/commit/e19b53fd2f75bde532d09673f0505b533daa6cb9#commitcomment-38321380))

To fix the issue, i used a simple custom flag on video element to avoid unnecessary additional call of load() method.

It should fixes Clappr player issues [1984](https://github.com/clappr/clappr/issues/1984) and [1982](https://github.com/clappr/clappr/issues/1982).