### PR TITLE
HTML5Video - Fix invalid getDuration method response

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -43,6 +43,7 @@ export default class HTML5Video extends Playback {
   get name() { return 'html5_video' }
   get supportedVersion() { return { min: VERSION } }
   get tagName() { return this.isAudioOnly ? 'audio' : 'video' }
+  get template() { return template(tracksHTML) }
 
   get isAudioOnly() {
     const resourceUrl = this.options.src
@@ -648,8 +649,6 @@ export default class HTML5Video extends Playback {
       id: trackId
     })
   }
-
-  get template() { return template(tracksHTML) }
 
   render() {
     this.options.playback.disableContextMenu && this.$el.on('contextmenu', () => { return false })

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -231,6 +231,7 @@ export default class HTML5Video extends Playback {
   }
 
   _onLoadedMetadata(e) {
+    this._ready()
     this._handleBufferingEvents()
     this.trigger(Events.PLAYBACK_LOADEDMETADATA, { duration: e.target.duration, data: e })
     this._updateSettings()
@@ -566,8 +567,7 @@ export default class HTML5Video extends Playback {
   }
 
   _ready() {
-    if (this._isReadyState)
-      return
+    if (this._isReadyState) return
 
     this._isReadyState = true
     this.trigger(Events.PLAYBACK_READY, this.name)
@@ -654,9 +654,9 @@ export default class HTML5Video extends Playback {
     this.options.playback.disableContextMenu && this.$el.on('contextmenu', () => { return false })
     this._externalTracks && this._externalTracks.length > 0 && this.$el.html(this.template({ tracks: this._externalTracks }))
 
-    this._ready()
     const style = Styler.getStyleFor(HTML5VideoStyle.toString(), { baseUrl: this.options.baseUrl })
     this.$el.append(style[0])
+
     return this
   }
 }

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -652,17 +652,8 @@ export default class HTML5Video extends Playback {
   get template() { return template(tracksHTML) }
 
   render() {
-    if (this.options.playback.disableContextMenu) {
-      this.$el.on('contextmenu', () => {
-        return false
-      })
-    }
-
-    if (this._externalTracks && this._externalTracks.length > 0) {
-      this.$el.html(this.template({
-        tracks: this._externalTracks,
-      }))
-    }
+    this.options.playback.disableContextMenu && this.$el.on('contextmenu', () => { return false })
+    this._externalTracks && this._externalTracks.length > 0 && this.$el.html(this.template({ tracks: this._externalTracks }))
 
     this._ready()
     const style = Styler.getStyleFor(HTML5VideoStyle.toString(), { baseUrl: this.options.baseUrl })

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -609,4 +609,14 @@ describe('HTML5Video playback', function() {
       expect(html5Video._updateDvr).toHaveBeenCalledWith(true)
     })
   })
+
+  describe('_onLoadedMetadata callback', () => {
+    test('calls _ready method', () => {
+      const playback = new HTML5Video({ src: '/test/fixtures/SampleVideo_360x240_1mb.mp4' })
+      jest.spyOn(playback, '_ready')
+      playback.el.dispatchEvent(new Event('loadedmetadata'))
+
+      expect(playback._ready).toHaveBeenCalledTimes(1)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

**TL;DR**: Fixes https://github.com/clappr/clappr/issues/1910.

Currently, the `HTML5Video` playback calls the `_ready` method even if the HTMLMediaElement is not ready yet. This PR moves the `_ready` call to inside the `_onLoadedMetadata` method, which will be called after the HTMLMediaElement `loadedmetadata` event occurs.

With this change, the `ready` event is only called after the HTMLMediaElement metadata is available.

## Changes

- `html5_video.js`:
  - Removes the `_ready` call inside `render` method;
  - Adds the `_ready` call inside `_onLoadedMetadata` method;
  - Simplify `if` statements inside `render` method;
  - Moves `template` for the to of class declaration;
- `html5_video.test.js`:
  - Creates tests for new code added on `_onLoadedMetadata` method;

## How to test

- Try to get media duration immediately after the `ready` state has updated on any Clappr scope.
  - E.g.: Set the option ```events: { onReady: function() { alert(`player.getDuration returns: ${this.getDuration()}`) } }``` on Clappr initial setup.
  - The alert should be rendered with the correct media duration value.

## A picture/video tells a thousand words

<details open>
  <summary>iMac with Firefox:</summary>
  <ul>
    <br>
    <details style= 'margin-left: 20px;'>
      <summary>Before this PR:</summary>
      <br>
      <img src="https://user-images.githubusercontent.com/5631063/113449163-a0cb6980-93d3-11eb-8db3-5b4d7e31c0d4.png">
    </details>
    <details style= 'margin-left: 20px;'>
      <summary>After this PR:</summary>
      <br>
      <img src="https://user-images.githubusercontent.com/5631063/113449338-fef84c80-93d3-11eb-9a61-f41c885d8297.png">
    </details>
  </ul>
</details>
<br>
<details open>
  <summary>iOS with Safari:</summary>
  <ul>
    <br>
    <details style= 'margin-left: 20px;'>
      <summary>Before this PR:</summary>
      <br>
      <img src="https://user-images.githubusercontent.com/5631063/113449603-92ca1880-93d4-11eb-8c70-a0f1d83346b2.jpeg">
    </details>
    <details style= 'margin-left: 20px;'>
      <summary>After this PR:</summary>
      <br>
      <img src="https://user-images.githubusercontent.com/5631063/113449640-a70e1580-93d4-11eb-9f99-45e7802ddee7.jpeg">
    </details>
  </ul>
</details>