### PR TITLE
Add mouse down & mouse up events

### DIFF
--- a/src/base/events/events.js
+++ b/src/base/events/events.js
@@ -732,6 +732,9 @@ Events.CONTAINER_DBLCLICK = 'container:dblclick'
 Events.CONTAINER_CONTEXTMENU = 'container:contextmenu'
 Events.CONTAINER_MOUSE_ENTER = 'container:mouseenter'
 Events.CONTAINER_MOUSE_LEAVE = 'container:mouseleave'
+Events.CONTAINER_MOUSE_UP = 'container:mouseup'
+Events.CONTAINER_MOUSE_DOWN = 'container:mousedown'
+
 /**
  * Fired when the container seeks the video
  *

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -40,7 +40,9 @@ export default class Container extends UIObject {
       'touchend': 'dblTap',
       'contextmenu': 'onContextMenu',
       'mouseenter': 'mouseEnter',
-      'mouseleave': 'mouseLeave'
+      'mouseleave': 'mouseLeave',
+      'mouseup': 'onMouseUp',
+      'mousedown': 'onMouseDown'
     }
   }
 
@@ -449,6 +451,16 @@ export default class Container extends UIObject {
     if (!this.options.chromeless || this.options.allowUserInteraction)
       this.trigger(Events.CONTAINER_MOUSE_LEAVE)
 
+  }
+
+  mouseUp() {
+    if (!this.options.chromeless || this.options.allowUserInteraction)
+      this.trigger(Events.CONTAINER_MOUSE_UP)
+  }
+
+  mouseDown() {
+    if (!this.options.chromeless || this.options.allowUserInteraction)
+      this.trigger(Events.CONTAINER_MOUSE_DOWN)
   }
 
   settingsUpdate() {


### PR DESCRIPTION
## Summary

I noticed that Clappr has no support for mouse down/mouse up events. Those can be used for creative features, for example: http://view.wirewax.com/8117237. So i decided to try implementing it.

## Changes

- Added mouse up event
- Added mouse down event

## How to test

Just try binding the mouse down/up event to player with `listenTo`

### Before this PR

 On mouse click'n'hold -> Only click event fired

### After this PR

On mouse click'n'hold -> Click and mouse down events fired
On mouse click drop -> mouse up event fired.

For reference, please check https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseup_event

For compatibilities
https://caniuse.com/mdn-api_element_mouseup_event
https://caniuse.com/mdn-api_element_mousedown_event