### PR TITLE
Playback: add audio track public API and events

### DIFF
--- a/src/base/events/events.js
+++ b/src/base/events/events.js
@@ -552,6 +552,20 @@ Events.PLAYBACK_SUBTITLE_AVAILABLE = 'playback:subtitle:available'
  */
 Events.PLAYBACK_SUBTITLE_CHANGED = 'playback:subtitle:changed'
 
+/**
+ * Fired when audio tracks are available to be used on the playback
+ * @event PLAYBACK_AUDIO_AVAILABLE
+ * @param {import('../playback/playback').AudioTrack[]} tracks - list of available audio tracks
+ */
+Events.PLAYBACK_AUDIO_AVAILABLE = 'playback:audio:available'
+
+/**
+ * Fired whenever the current audio track has changed
+ * @event PLAYBACK_AUDIO_CHANGED
+ * @param {import('../playback/playback').AudioTrack} track - audio track active after change
+ */
+Events.PLAYBACK_AUDIO_CHANGED = 'playback:audio:changed'
+
 // Core Events
 /**
  * Fired when the containers are created
@@ -696,6 +710,20 @@ Events.CONTAINER_SUBTITLE_AVAILABLE = 'container:subtitle:available'
  * selected track id
  */
 Events.CONTAINER_SUBTITLE_CHANGED = 'container:subtitle:changed'
+
+/**
+ * Fired when audio tracks are available to be used on the container
+ * @event CONTAINER_AUDIO_AVAILABLE
+ * @param {import('../playback/playback').AudioTrack[]} tracks - list of available audio tracks
+ */
+Events.CONTAINER_AUDIO_AVAILABLE = 'container:audio:available'
+
+/**
+  * Fired whenever the current audio track has changed
+  * @event CONTAINER_AUDIO_CHANGED
+  * @param {import('../playback/playback').AudioTrack} track - audio track active after change
+  */
+Events.CONTAINER_AUDIO_CHANGED = 'container:audio:changed'
 
 /**
  * Fired when the time is updated on container

--- a/src/base/playback/playback.js
+++ b/src/base/playback/playback.js
@@ -5,6 +5,16 @@ import ErrorMixin from '@/base/error_mixin'
 import $ from 'clappr-zepto'
 
 /**
+ * An object representing a single audio track.
+ * @typedef {Object} AudioTrack
+ * @property {string} id - A unique identifier for the track. Used to identify it among the others.
+ * @property {string} language - The language of the track (e.g., 'en', 'pt-BR').
+ * @property {string} [label] - An optional label to be used in the UI to describe the track.
+ * @property {('main'|'description')} kind - The category the audio track belongs to.
+ * The kind 'description' is applied to audio tracks that narrate or describe the visual content.
+ */
+
+/**
  * An abstraction to represent a generic playback, it's like an interface to be implemented by subclasses.
  * @class Playback
  * @constructor
@@ -173,6 +183,24 @@ export default class Playback extends UIObject {
    * @type {Number}
    */
   set closedCaptionsTrackId(trackId) {} // eslint-disable-line no-unused-vars
+
+  /**
+   * returns a list of the available audio tracks for the playback.
+   * @type {AudioTrack[]} audio tracks
+   */
+  get audioTracks() { return [] }
+
+  /**
+   * returns the audio track currently in use by the playback.
+   * @type {AudioTrack} audio track
+   */
+  get currentAudioTrack() { return null }
+
+  /**
+   * switches the current audio track used by the playback.
+   * @param {string} id - id of the audio track to be set.
+   */
+  switchAudioTrack(id) {} // eslint-disable-line no-unused-vars
 
   /**
    * gets the playback type (`'vod', 'live', 'aod'`)

--- a/src/base/playback/playback.test.js
+++ b/src/base/playback/playback.test.js
@@ -44,6 +44,14 @@ describe('Playback', function() {
       expect(isGetterProperty(this.basePlayback, 'isReady')).toBeTruthy()
       expect(isSetterProperty(this.basePlayback, 'isReady')).toBeFalsy()
     })
+    test('called audioTracks', () => {
+      expect(isGetterProperty(this.basePlayback, 'audioTracks')).toBeTruthy()
+      expect(isSetterProperty(this.basePlayback, 'audioTracks')).toBeFalsy()
+    })
+    test('called currentAudioTracks', () => {
+      expect(isGetterProperty(this.basePlayback, 'currentAudioTrack')).toBeTruthy()
+      expect(isSetterProperty(this.basePlayback, 'currentAudioTrack')).toBeFalsy()
+    })
     test('called hasClosedCaptionsTracks', () => {
       expect(isGetterProperty(this.basePlayback, 'hasClosedCaptionsTracks')).toBeTruthy()
       expect(isSetterProperty(this.basePlayback, 'hasClosedCaptionsTracks')).toBeFalsy()
@@ -88,6 +96,14 @@ describe('Playback', function() {
 
   test('closedCaptionsTrackId getter returns default value', () => {
     expect(this.basePlayback.closedCaptionsTrackId).toEqual(-1)
+  })
+
+  test('audioTracks getter returns default value', () => {
+    expect(this.basePlayback.audioTracks).toEqual([])
+  })
+
+  test('currentAudioTrack getter returns default value', () => {
+    expect(this.basePlayback.currentAudioTrack).toBeNull()
   })
 
   test('i18n getter returns default value', () => {

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -112,6 +112,22 @@ export default class Container extends UIObject {
   }
 
   /**
+   * returns a list of the available audio tracks.
+   * @type {import('../../base/playback/playback').AudioTrack[]} audio tracks
+   */
+  get audioTracks() {
+    return this.playback.audioTracks
+  }
+
+  /**
+  * returns the audio track currently in use.
+  * @type {import('../../base/playback/playback').AudioTrack} audio track
+  */
+  get currentAudioTrack() {
+    return this.playback.currentAudioTrack
+  }
+
+  /**
    * it builds a container
    * @method constructor
    * @param {Object} options the options object
@@ -186,6 +202,8 @@ export default class Container extends UIObject {
     this.listenTo(this.playback, Events.PLAYBACK_ERROR, this.error)
     this.listenTo(this.playback, Events.PLAYBACK_SUBTITLE_AVAILABLE, this.subtitleAvailable)
     this.listenTo(this.playback, Events.PLAYBACK_SUBTITLE_CHANGED, this.subtitleChanged)
+    this.listenTo(this.playback, Events.PLAYBACK_AUDIO_AVAILABLE, this.audioAvailable)
+    this.listenTo(this.playback, Events.PLAYBACK_AUDIO_CHANGED, this.audioChanged)
   }
 
   subtitleAvailable() {
@@ -194,6 +212,14 @@ export default class Container extends UIObject {
 
   subtitleChanged(track) {
     this.trigger(Events.CONTAINER_SUBTITLE_CHANGED, track)
+  }
+
+  audioAvailable(tracks) {
+    this.trigger(Events.CONTAINER_AUDIO_AVAILABLE, tracks)
+  }
+
+  audioChanged(track) {
+    this.trigger(Events.CONTAINER_AUDIO_CHANGED, track)
   }
 
   playbackStateChanged(state) {
@@ -331,6 +357,10 @@ export default class Container extends UIObject {
     this.actionsMetadata.stopEvent = customData
     this.playback.stop(customData)
     this.currentTime = 0
+  }
+
+  switchAudioTrack(id) {
+    this.playback.switchAudioTrack(id)
   }
 
   /**

--- a/src/components/container/container.test.js
+++ b/src/components/container/container.test.js
@@ -29,6 +29,33 @@ describe('Container', function() {
     expect( this.container.getPlugin('fake')).toEqual(plugin)
   })
 
+  test('delegates audioTracks calls to playback', () => {
+    const audioTracks = []
+    jest.spyOn(this.playback, 'audioTracks', 'get').mockReturnValue(audioTracks)
+
+    const result = this.container.audioTracks
+
+    expect(result).toBe(audioTracks)
+  })
+
+  test('delegates currentAudioTrack calls to playback', () => {
+    const currentAudioTrack = {}
+    jest.spyOn(this.playback, 'currentAudioTrack', 'get').mockReturnValue(currentAudioTrack)
+
+    const result = this.container.currentAudioTrack
+
+    expect(result).toBe(currentAudioTrack)
+  })
+
+  test('delegates switchAudioTrack calls to playback', () => {
+    jest.spyOn(this.playback, 'switchAudioTrack').mockImplementation()
+
+    this.container.switchAudioTrack(42)
+
+    expect(this.playback.switchAudioTrack).toHaveBeenCalledTimes(1)
+    expect(this.playback.switchAudioTrack).toHaveBeenCalledWith(42)
+  })
+
   test('destroys all the plugins', () => {
     const fakePlugin = { destroy: () => {} }
 
@@ -234,6 +261,26 @@ describe('Container', function() {
     this.playback.trigger(Events.PLAYBACK_STOP)
     
     expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_STOP, parameter)
+  })
+
+  test('triggers CONTAINER_AUDIO_AVAILABLE when PLAYBACK_AUDIO_AVAILABLE happens', () => {
+    const audioTracks = []
+    jest.spyOn(this.container, 'trigger')
+    this.container.bindEvents()
+
+    this.playback.trigger(Events.PLAYBACK_AUDIO_AVAILABLE, audioTracks)
+
+    expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_AUDIO_AVAILABLE, audioTracks)
+  })
+
+  test('triggers CONTAINER_AUDIO_CHANGED when PLAYBACK_AUDIO_CHANGED happens', () => {
+    const audioTracks = []
+    jest.spyOn(this.container, 'trigger')
+    this.container.bindEvents()
+
+    this.playback.trigger(Events.PLAYBACK_AUDIO_CHANGED, audioTracks)
+
+    expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_AUDIO_CHANGED, audioTracks)
   })
 
   describe('#checkResize', () => {


### PR DESCRIPTION
## Summary

This PR introduces a new API to the playback interface to standardize the way audio tracks are queried and updated. As of now, Clappr does not provide a set of APIs on the playback to interact with the audio tracks in the stream (i.e., when the content is adaptive) nor does it provide events that other plugins can subscribe to when something happens to the audio tracks.

In order to address the aforementioned issues, 3 methods/properties were added to the playback interface and 2 events were defined:

### Methods/Properties
* `get audioTracks`: returns a list of audio tracks available to be used by the playback;
* `get currentAudioTrack`: returns the audio track that is active at the moment;
* `switchAudioTrack(id)`: updates the current audio track to the one with the provided id.

### Events
* `PLAYBACK_AUDIO_AVAILABLE`: event trigged when the audio tracks on the playback are available to be used;
* `PLAYBACK_AUDIO_CHANGED`: event trigged when the current audio track on the playback is updated;

Furthermore, a common interface to the audio track object is proposed here. It is heavily inspired by the one in the [HTML standard](https://developer.mozilla.org/en-US/docs/Web/API/AudioTrack). Concrete playbacks should respect this interface when implementing these methods and triggering these events in order to avoid the need for adapters.

To respect the Clappr architecture, the same methods and events were ported to the container class and scope.

## Changes

* playback.js
  * added method/properties stubs to be implemented by concrete playbacks.
    * `get audioTracks`
    * `get currentAudioTrack`
    * `switchAudioTrack(id)`
 * container.js
   * added method/properties delegating calls to the playback.
     * `get audioTracks`
     * `get currentAudioTrack`
     * `switchAudioTrack(id)`
  * re-raised audio track events on the container scope.
* events.js
  * added `PLAYBACK_AUDIO_AVAILABLE` event.
  * added `PLAYBACK_AUDIO_CHANGED` event.
  * added `CONTAINER_AUDIO_AVAILABLE` event.
  * added `CONTAINER_AUDIO_CHANGED` event.
