### PR TITLE
Extend container actions accepting parameters

### DIFF
--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -315,32 +315,32 @@ export default class Container extends UIObject {
   /**
    * plays the playback
    * @method play
-   * @param {Object} options
+   * @param {Object} customData
    */
-  play(options = {}) {
-    this.actionsMetadata.playEvent = options
-    this.playback.play(options)
+  play(customData = {}) {
+    this.actionsMetadata.playEvent = customData
+    this.playback.play(customData)
   }
 
   /**
    * stops the playback
    * @method stop
-   * @param {Object} options
+   * @param {Object} customData
    */
-  stop(options = {}) {
-    this.actionsMetadata.stopEvent = options
-    this.playback.stop(options)
+  stop(customData = {}) {
+    this.actionsMetadata.stopEvent = customData
+    this.playback.stop(customData)
     this.currentTime = 0
   }
 
   /**
    * pauses the playback
    * @method pause
-   * @param {Object} options
+   * @param {Object} customData
    */
-  pause(options = {}) {
-    this.actionsMetadata.pauseEvent = options
-    this.playback.pause(options)
+  pause(customData = {}) {
+    this.actionsMetadata.pauseEvent = customData
+    this.playback.pause(customData)
   }
 
   onEnded() {

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -299,14 +299,17 @@ export default class Container extends UIObject {
 
   playing() {
     this.trigger(Events.CONTAINER_PLAY, this.name, this.actionsMetadata.playEvent || {})
+    this.actionsMetadata.playEvent = {}
   }
 
   paused() {
     this.trigger(Events.CONTAINER_PAUSE, this.name, this.actionsMetadata.pauseEvent || {})
+    this.actionsMetadata.pauseEvent = {}
   }
 
   stopped() {
     this.trigger(Events.CONTAINER_STOP, this.actionsMetadata.stopEvent || {})
+    this.actionsMetadata.stopEvent = {}
   }
 
   /**

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -131,6 +131,7 @@ export default class Container extends UIObject {
     this.dblTapHandler = new DoubleEventHandler(500)
     this.clickTimer = null
     this.clickDelay = 200  // FIXME: could be a player option
+    this.actionsMetadata = {}
     this.bindEvents()
   }
 
@@ -297,45 +298,51 @@ export default class Container extends UIObject {
   }
 
   playing() {
-    this.trigger(Events.CONTAINER_PLAY, this.name)
+    this.trigger(Events.CONTAINER_PLAY, this.name, this.actionsMetadata.playEvent || {})
   }
 
   paused() {
-    this.trigger(Events.CONTAINER_PAUSE, this.name)
+    this.trigger(Events.CONTAINER_PAUSE, this.name, this.actionsMetadata.pauseEvent || {})
+  }
+
+  stopped() {
+    this.trigger(Events.CONTAINER_STOP, this.actionsMetadata.stopEvent || {})
   }
 
   /**
    * plays the playback
    * @method play
+   * @param {Object} options
    */
-  play() {
-    this.playback.play()
+  play(options = {}) {
+    this.actionsMetadata.playEvent = options
+    this.playback.play(options)
   }
 
   /**
    * stops the playback
    * @method stop
+   * @param {Object} options
    */
-  stop() {
-    this.playback.stop()
+  stop(options = {}) {
+    this.actionsMetadata.stopEvent = options
+    this.playback.stop(options)
     this.currentTime = 0
   }
 
   /**
    * pauses the playback
    * @method pause
+   * @param {Object} options
    */
-  pause() {
-    this.playback.pause()
+  pause(options = {}) {
+    this.actionsMetadata.pauseEvent = options
+    this.playback.pause(options)
   }
 
   onEnded() {
     this.trigger(Events.CONTAINER_ENDED, this, this.name)
     this.currentTime = 0
-  }
-
-  stopped() {
-    this.trigger(Events.CONTAINER_STOP)
   }
 
   clicked() {

--- a/src/components/container/container.test.js
+++ b/src/components/container/container.test.js
@@ -184,6 +184,62 @@ describe('Container', function() {
     expect(this.container.playing).toHaveBeenCalledTimes(1)
   })
 
+  test('trigger container:pause with no parameters', () => {
+    jest.spyOn(this.container, 'trigger')
+    this.container.pause()
+    this.playback.trigger(Events.PLAYBACK_PAUSE)
+
+    expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_PAUSE, this.container.name, {})
+  })
+
+  test('trigger container:pause with parameters', () => {
+    jest.spyOn(this.container, 'trigger')
+    const parameter = { anyParameter: 'parameter' }
+    this.container.pause(parameter)
+    this.playback.trigger(Events.PLAYBACK_PAUSE)
+
+
+    expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_PAUSE, this.container.name, parameter)
+    expect(this.container.actionsMetadata).toEqual({ pauseEvent: parameter })
+
+  })
+
+  test('trigger container:play with no parameters', () => {
+    jest.spyOn(this.container, 'trigger')
+    this.container.pause()
+    this.playback.trigger(Events.PLAYBACK_PLAY)
+
+    expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_PLAY, this.container.name, {})
+  })
+
+  test('trigger container:play with parameters', () => {
+    jest.spyOn(this.container, 'trigger')
+    const parameter = { anyParameter: 'parameter' }
+    this.container.play(parameter)
+    this.playback.trigger(Events.PLAYBACK_PLAY)
+    
+    expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_PLAY, this.container.name, parameter)
+    expect(this.container.actionsMetadata).toEqual({ playEvent: parameter })
+  })
+
+  test('trigger container:stop with no parameters', () => {
+    jest.spyOn(this.container, 'trigger')
+    this.container.stop()
+    this.playback.trigger(Events.PLAYBACK_STOP)
+
+    expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_STOP, {})
+  })
+
+  test('trigger container:stop with parameters', () => {
+    jest.spyOn(this.container, 'trigger')
+    const parameter = { anyParameter: 'parameter' }
+    this.container.stop(parameter)
+    this.playback.trigger(Events.PLAYBACK_STOP)
+    
+    expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_STOP, parameter)
+    expect(this.container.actionsMetadata).toEqual({ stopEvent: parameter })
+  })
+
   describe('#checkResize', () => {
     beforeEach(() => {
       this.container.el = { clientWidth: 640, clientHeight: 360 }

--- a/src/components/container/container.test.js
+++ b/src/components/container/container.test.js
@@ -200,8 +200,6 @@ describe('Container', function() {
 
 
     expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_PAUSE, this.container.name, parameter)
-    expect(this.container.actionsMetadata).toEqual({ pauseEvent: parameter })
-
   })
 
   test('trigger container:play with no parameters', () => {
@@ -219,7 +217,6 @@ describe('Container', function() {
     this.playback.trigger(Events.PLAYBACK_PLAY)
     
     expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_PLAY, this.container.name, parameter)
-    expect(this.container.actionsMetadata).toEqual({ playEvent: parameter })
   })
 
   test('trigger container:stop with no parameters', () => {
@@ -237,7 +234,6 @@ describe('Container', function() {
     this.playback.trigger(Events.PLAYBACK_STOP)
     
     expect(this.container.trigger).toHaveBeenCalledWith(Events.CONTAINER_STOP, parameter)
-    expect(this.container.actionsMetadata).toEqual({ stopEvent: parameter })
   })
 
   describe('#checkResize', () => {


### PR DESCRIPTION
## Summary

This PR allows Containers actions such as `play`, `pause`, and `stop`, to receive parameters and bridge these parameters to the `Playback`.

The Container events related to these actions will send the parameters to anything who is listening to these `container events`.

## Changes

- `src/components/container/container.js`: Allows `play`, `pause`, and `stop` methods to receive parameters and store them on `actionsMetadata` key. These parameters are sent when Container triggers related events.
- `src/components/container/container.test.js`: Create tests for Container extension. 

## How to test

1. Run this PR project
2. On the Developer Tools, listen to Containers `play`, `pause`, or `stop`, and log his callback. Ex: `player.listenTo(player.core.activeContainer, Clappr.Events.CONTAINER_PAUSE, (...args) => console.log('Arguments: ', ...args))`
3. Call the related Container method with any argument. Eg: `player.core.activeContainer.pause({test: 'any'})`
4. The Developer Tools should Output these arguments.