### PR TITLE
Core - Fix integration with full screen controls in iOS

### DIFF
--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -316,11 +316,11 @@ export default class Core extends UIObject {
   isFullscreen() {
     // Ensure current instance is in fullscreen mode by checking fullscreen element
     const fullscreenElement = Fullscreen.fullscreenElement()
-
-    if (!fullscreenElement) return false
-
-    const playbackEl = this.activePlayback && this.activePlayback.el
-    return (fullscreenElement === this.el) || (fullscreenElement === playbackEl)
+    const isElementInFullscreen = fullscreenElement && ((fullscreenElement === this.el) 
+    || (fullscreenElement === this.activePlaybackEl)) 
+    || this.activePlaybackEl.webkitDisplayingFullscreen
+    
+    return isElementInFullscreen 
   }
 
   toggleFullscreen() {

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -325,10 +325,11 @@ export default class Core extends UIObject {
 
   toggleFullscreen() {
     if (this.isFullscreen()) {
-      Fullscreen.cancelFullscreen()
+      const fullscreenEl = Browser.isiOS ? this.activePlaybackEl : document
+      Fullscreen.cancelFullscreen(fullscreenEl)
       !Browser.isiOS && this.$el.removeClass('fullscreen nocursor')
     } else {
-      const fullscreenEl = Browser.isiOS ? this.activePlayback && this.activePlayback.el : this.el
+      const fullscreenEl = Browser.isiOS ? this.activePlaybackEl : this.el
       if (!fullscreenEl) return
 
       (Browser.isSafari || Browser.isiOS) // Safari doesn't return a promise like the other browsers. See more in https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -103,6 +103,15 @@ export default class Core extends UIObject {
     return this.activeContainer && this.activeContainer.playback
   }
 
+  /**
+   * gets the active playback's video element.
+   * @property activePlaybackEl
+   * @type {Object}
+   */
+  get activePlaybackEl() {
+    return this.activePlayback.$el.find('video')[0] || this.activePlayback.el
+  }
+
   constructor(options) {
     super(options)
     this.playerError = new PlayerError(options, this)


### PR DESCRIPTION
## Summary

This PR fixes two issues related to the use of full screen mode on Clappr in iOS.

Previously, Clappr's `core` method `isFullscreen` used `document` variables (e.g. `fullscreenElement`) to identify if the player was on full screen mode. This couldn't be verified, however, when using an iOS device, in which case, the `video` element's `webkitDisplayingFullscreen` variable must be checked.

Clappr's `core` method `toggleFullscreen` wasn't able to deactivate full screen mode programmatically in iOS devices. This happened because `cancelFullscreen` was never called with Clappr's `video` element when running the player in iOS, using the default `document` element.

## Changes

- Clappr's `core` can now identify correctly if Clappr is on Full screen mode in iOS;
- Clappr's `core` can now cancel Full screen mode in iOS programmatically.

## How to test

1. Run Clappr on an iPhone with any video.
2. Connect your iPhone and access its Web Inspector.
3. In your Web Inspector's console, check `player.core.isFullscreen()`. It should return `false`.
4. Try to activate full screen mode with `player.core.toggleFullscreen()`.
5. In your Web Inspector's console, check `player.core.isFullscreen()`. It should return `true`.
6. Try to deactivate fullscreen with `player.core.toggleFullscreen()`.