### PR TITLE
docs: fix broken URL for "all existing events"

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ For example, the `CONTAINER_STATE_BUFFERING` event is triggered by the `containe
 player.core.activeContainer.on(Clappr.Events.CONTAINER_STATE_BUFFERING, function() { ... })
 ```
 
-See all existing events on Clappr [here](https://github.com/clappr/clappr-core/blob/master/src/base/events.js#L227).
+See all existing events on Clappr [here](https://github.com/clappr/clappr-core/blob/master/src/base/events/events.js#L227).
 
 #### plugins
 An object used to config external plugins instances and plugins behaviors to Clappr.


### PR DESCRIPTION
## Summary

Fix of issue #79, there was a broken link for the events' source code.

## Changes

- Fixed the broken link

## How to test

- Try accessing the URL

## A picture/video tells a thousand words

### Before this PR

![image](https://user-images.githubusercontent.com/27526023/193362912-b15aa304-d31f-48fd-93db-10d17d924547.png)


### After this PR

![image](https://user-images.githubusercontent.com/27526023/193362966-7242a23a-028f-4dab-b55c-22033cf470a4.png)
