### PR TITLE
docs: fix broken URL for "all existing events"

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ For example, the `CONTAINER_STATE_BUFFERING` event is triggered by the `containe
 player.core.activeContainer.on(Clappr.Events.CONTAINER_STATE_BUFFERING, function() { ... })
 ```
 
-See all existing events on Clappr [here](https://github.com/clappr/clappr-core/blob/master/src/base/events.js#L227).
+See all existing events on Clappr [here](https://github.com/clappr/clappr-core/blob/master/src/base/events/events.js#L227).
 
 #### plugins
 An object used to config external plugins instances and plugins behaviors to Clappr.


### PR DESCRIPTION
Fixes issue #79. 

Same PR as i did before on #84, just reopened (due to hacktoberfest contribution). 