### PR TITLE
Callbacks – Add Event Parameters from Container Actions

### DIFF
--- a/src/components/player/player.js
+++ b/src/components/player/player.js
@@ -352,16 +352,16 @@ export default class Player extends BaseObject {
     this.trigger(Events.PLAYER_RESIZE, size)
   }
 
-  _onPlay() {
-    this.trigger(Events.PLAYER_PLAY)
+  _onPlay(_, eventMetadata = {}) {
+    this.trigger(Events.PLAYER_PLAY, eventMetadata)
   }
 
-  _onPause() {
-    this.trigger(Events.PLAYER_PAUSE)
+  _onPause(_, eventMetadata = {}) {
+    this.trigger(Events.PLAYER_PAUSE, eventMetadata)
   }
 
-  _onStop() {
-    this.trigger(Events.PLAYER_STOP, this.getCurrentTime())
+  _onStop(eventMetadata = {}) {
+    this.trigger(Events.PLAYER_STOP, this.getCurrentTime(), eventMetadata)
   }
 
   _onEnded() {
@@ -444,30 +444,33 @@ export default class Player extends BaseObject {
   /**
    * plays the current video (`source`).
    * @method play
+   * @param {Object} customData
    * @return {Player} itself
    */
-  play() {
-    this.core.activeContainer.play()
+  play(customData = {}) {
+    this.core.activeContainer.play(customData)
     return this
   }
 
   /**
    * pauses the current video (`source`).
    * @method pause
+   * @param {Object} customData
    * @return {Player} itself
    */
-  pause() {
-    this.core.activeContainer.pause()
+  pause(customData = {}) {
+    this.core.activeContainer.pause(customData)
     return this
   }
 
   /**
    * stops the current video (`source`).
    * @method stop
+   * @param {Object} customData
    * @return {Player} itself
    */
-  stop() {
-    this.core.activeContainer.stop()
+  stop(customData = {}) {
+    this.core.activeContainer.stop(customData)
     return this
   }
 


### PR DESCRIPTION
## Summary

This PR allows Clappr's callbacks such as `onPlay`, `onPause`, and `onStop` to receive parameters from the  `actionsMetadata` object sent through the Clappr's `Container` methods (`play`, `pause` and `stop`).

For more context, the `actionsMetadata` object was introduced in https://github.com/clappr/clappr-core/pull/73. 

## Changes

- `player.js`: Allows the `onPlay`, `onPause`, and `onStop` callbacks to use parameters from Container actions' `actionsMetadata` object.

## How to test

1. Run this branch with the following callbacks configured in the Player `options`:
```
events: {
  onPlay: (eventMetadata) => { console.log(eventMetadata) },
  onPause: (eventMetadata) => { console.log(eventMetadata) },
  onStop: (currentTime, eventMetadata) => { console.log(eventMetadata) },
}
```
2. On your browser's Developer Tools console, call the following methods. The callback should output a log of the inserted object.
```
player.play({ play: true })
player.pause({ pause: true })
player.stop({ stop: true })

player.core.activeContainer.play({ play: true })
player.core.activeContainer.pause({ pause: true })
player.core.activeContainer.stop({ stop: true })
``` 