### PR TITLE
Fix attach element on Player constructor

### DIFF
--- a/src/components/player/player.js
+++ b/src/components/player/player.js
@@ -252,7 +252,7 @@ export default class Player extends BaseObject {
     this._registerOptionEventListeners(this.options.events)
     this._coreFactory = new CoreFactory(this)
     const parentElement = this._getParentElement(this.options)
-    this.attachTo(parentElement)
+    parentElement && this.attachTo(parentElement)
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR fixes an issue introduced in https://github.com/clappr/clappr-core/pull/82 that allowed the attaching of an undefined element.

## Changes

- `player.js`: Add conditional to attaching of `parentElement`