### PR TITLE
Browser – Fix Microsoft Edge User Agent Identification

### DIFF
--- a/src/components/browser/browser.js
+++ b/src/components/browser/browser.js
@@ -182,10 +182,10 @@ export const getDevice = function(ua) {
 
 const browserInfo = getBrowserInfo(navigator.userAgent)
 
-Browser.isEdge = /edge/i.test(navigator.userAgent)
-Browser.isChrome = /chrome|CriOS/i.test(navigator.userAgent) && !Browser.isEdge
-Browser.isSafari = /safari/i.test(navigator.userAgent) && !Browser.isChrome && !Browser.isEdge
-Browser.isFirefox = /firefox/i.test(navigator.userAgent)
+Browser.isEdge = /Edg|EdgiOS|EdgA/i.test(navigator.userAgent)
+Browser.isChrome = /Chrome|CriOS/i.test(navigator.userAgent) && !Browser.isEdge
+Browser.isSafari = /Safari/i.test(navigator.userAgent) && !Browser.isChrome && !Browser.isEdge
+Browser.isFirefox = /Firefox/i.test(navigator.userAgent)
 Browser.isLegacyIE = !!(window.ActiveXObject)
 Browser.isIE = Browser.isLegacyIE || /trident.*rv:1\d/i.test(navigator.userAgent)
 Browser.isIE11 = /trident.*rv:11/i.test(navigator.userAgent)


### PR DESCRIPTION
## Summary

This PR fixes the `isEdge` method from the `Browser` class. Its identification of Microsoft's current browser was deprecated.

For more information on this change, check [Microsoft's Edge documentation on User-Agent identification](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance).

## How to test

1. Access each of the main browsers (Chrome, Edge, Firefox, Safari) and check if their respective methods are working (`isChrome`, `isEdge`, `isFirefox`, `isSafari`) 

## Images
### After this PR

<img width="1440" alt="Captura de Tela 2023-01-04 às 10 19 13" src="https://user-images.githubusercontent.com/40682476/210564520-5a340f7c-c67e-491e-b5d3-fde3036cfa65.png">