### PR TITLE
Browser – Operational System Identifiers

### DIFF
--- a/src/components/browser/browser.js
+++ b/src/components/browser/browser.js
@@ -217,6 +217,11 @@ Browser.version = browserInfo.version
 Browser.userAgent = navigator.userAgent
 Browser.data = getBrowserData()
 Browser.os = getOsData()
+
+Browser.isWindows = /^Windows$/i.test(Browser.os.group)
+Browser.isMacOS = /^Mac OS$/i.test(Browser.os.group)
+Browser.isLinux = /^Linux$/i.test(Browser.os.group)
+
 Browser.viewport = getViewportSize()
 Browser.device = getDevice(Browser.userAgent)
 typeof window.orientation !== 'undefined' && setViewportOrientation()


### PR DESCRIPTION
## Summary

This PR implements the new getters `isWindows`, `isMacOS` and `isLinux`, which identify the device's operational system.

## How to test

1. Run Clappr.
1. Access your browser of choice and type the following in your DevTools:
```
console.log({
  isWindows: Clappr.Browser.isWindows,
  isMacOS: Clappr.Browser.isMacOS,
  isLinux: Clappr.Browser.isLinux,
})
```
3. It should return correctly.

## Images
### After this PR

<img width="357" alt="Captura de Tela 2023-01-05 às 14 03 36" src="https://user-images.githubusercontent.com/40682476/210838695-8ad803e0-dc84-41c2-b276-e1bd58fe1e36.png">