### PR TITLE
Adding load method for playback pattern creation

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -216,6 +216,16 @@ export default class HTML5Video extends Playback {
 
   /**
    * Sets the source url on the <video> element, and also the 'src' property.
+   * @method load
+   * @public
+   * @param {String} srcUrl The source URL.
+   */
+  load(srcUrl) {
+    this._setupSrc(srcUrl)
+  }
+
+  /**
+   * Sets the source url on the <video> element, and also the 'src' property.
    * @method setupSrc
    * @private
    * @param {String} srcUrl The source URL.

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -112,6 +112,10 @@ export default class HTML5Video extends Playback {
     return typeof (this.minimumDVRSizeConfig) !== 'undefined' && typeof (this.minimumDVRSizeConfig) === 'number'
   }
 
+  get sourceMedia() {
+    return this._src
+  }
+
   constructor(...args) {
     super(...args)
     this._destroyed = false

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -298,8 +298,8 @@ export default class HTML5Video extends Playback {
     let promise = this.el.play()
     // For more details, see https://developers.google.com/web/updates/2016/03/play-returns-promise
     if (promise && promise.catch)
-      promise.catch(() => {})
-
+      promise.catch(error => Log.warn(this.name, 'HTML5 play failed', error))
+    return promise
   }
 
   pause() {


### PR DESCRIPTION
## Summary

This PR adds a `load` method and a `sourceMedia` getter, implementing a pattern for Clappr playback.
Besides that, a log message for play failed was added.

## How to test

1. Run the project
3. Play the video
4. Load another media and play it using:
```javascript
player.core.activePlayback.load('http://clappr.io/highline.mp4')
player.core.activePlayback.play()
```
6. The video should be played correctly.