### PR TITLE
fix(package): fix node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "npm run release"
   },
   "engines": {
-    "node": "^v14.0.0"
+    "node": ">=14"
   },
   "files": [
     "/dist",


### PR DESCRIPTION
## Summary

This PR fixes the node versions that the clappr core can work with. The current value with `^` allows only node with major version 14, versions above give the following error

```
error @clappr/core@0.5.0: The engine "node" is incompatible with this module. Expected version "^v14.0.0". Got "16.20.0"
error Found incompatible module.
```

To set a range of several major versions, npm recommends using characters `>=`, `<=` https://docs.npmjs.com/cli/v6/configuring-npm/package-json#engines

## Changes

- `package.json`

## How to test

1. Run `yarn add @clappr/core` with node 16+