### PR TITLE
fix: typo in playback not supported message

### DIFF
--- a/src/plugins/strings/strings.js
+++ b/src/plugins/strings/strings.js
@@ -54,7 +54,7 @@ export default class Strings extends CorePlugin {
         'live': 'ao vivo',
         'back_to_live': 'voltar para o ao vivo',
         'disabled': 'Desativado',
-        'playback_not_supported': 'Seu navegador não supporta a reprodução deste video. Por favor, tente usar um navegador diferente.',
+        'playback_not_supported': 'Seu navegador não suporta a reprodução deste video. Por favor, tente usar um navegador diferente.',
         'default_error_title': 'Não foi possível reproduzir o vídeo.',
         'default_error_message': 'Ocorreu um problema ao tentar carregar o vídeo.',
       },


### PR DESCRIPTION
## Summary

`This PR fixes a typo in unsupported playback message`

<!-- Add a description of the changes made to your PR, as well as the context and motivation behind them.

Please add, if appropriate, external links that make the PR easier to understand.
-->

## Changes

- `strings.js`:
  - Fix the word "supporta" to "suporta"

## How to test

1. Using a unsupported media check the message in portuguese

## Images

### Before this PR

<img width="1335" alt="image" src="https://github.com/clappr/clappr-core/assets/16838209/ef6979f7-1cf4-4df7-9a0f-9602e7b3c59b">


<!-- 
Insert an image / gif / video showing the Player's original behavior. 
If PR is a new feature, it's unnecessary to add.
-->

### After this PR

<img width="1335" alt="image" src="https://github.com/clappr/clappr-core/assets/16838209/15ed4e40-2188-436a-a1a2-8406c5ba0b6e">

<!-- Insert an image / gif / video showing the Player's behavior after the modifications -->
