### PR TITLE
HTML5 Video - Allow customizing playhead moving check

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -127,6 +127,7 @@ export default class HTML5Video extends Playback {
     this._ccTrackId = -1
     this._playheadMovingCheckEnabled = !this.options.disablePlayheadMovingCheck
     this._setupSrc(this.options.src)
+    this._playheadMovingCheckInterval = this.options.playheadMovingCheckInterval || 500
     // backwards compatibility (TODO: remove on 0.3.0)
     this.options.playback || (this.options.playback = this.options || {})
     this.options.playback.disableContextMenu = this.options.playback.disableContextMenu || this.options.disableVideoTagContextMenu
@@ -378,7 +379,7 @@ export default class HTML5Video extends Playback {
 
     this._playheadMovingTimeOnCheck = null
     this._determineIfPlayheadMoving()
-    this._playheadMovingTimer = setInterval(this._determineIfPlayheadMoving.bind(this), 500)
+    this._playheadMovingTimer = setInterval(this._determineIfPlayheadMoving.bind(this), this._playheadMovingCheckInterval)
   }
 
   _stopPlayheadMovingChecks() {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -700,7 +700,7 @@ export default class HTML5Video extends Playback {
   }
 }
 
-HTML5Video._mimeTypesForUrl = function(resourceUrl, mimeTypesByExtension, mimeType) {
+HTML5Video._mimeTypesForUrl = function(resourceUrl = '', mimeTypesByExtension, mimeType) {
   const extension = (resourceUrl.split('?')[0].match(/.*\.(.*)$/) || [])[1]
   let mimeTypes = mimeType || (extension && mimeTypesByExtension[extension.toLowerCase()]) || []
   return (mimeTypes.constructor === Array) ? mimeTypes : [mimeTypes]

--- a/src/playbacks/html5_video/html5_video.test.js
+++ b/src/playbacks/html5_video/html5_video.test.js
@@ -9,6 +9,7 @@ describe('HTML5Video playback', function() {
   })
 
   test('checks if it can play a resource', () => {
+    expect(HTML5Video.canPlay()).toBeFalsy()
     expect(HTML5Video.canPlay('')).toBeFalsy()
     expect(HTML5Video.canPlay('resource_without_dots')).toBeFalsy()
     // expect(HTML5Video.canPlay('http://domain.com/video.ogv')).toBeTruthy()


### PR DESCRIPTION
## Summary

This PR implements two new options to customize playhead moving check: `disablePlayheadMovingCheck` and `playheadMovingCheckInterval`.

The first one is used to disable the playhead moving check, and the second allows to customize the interval time between checks.

The motivation for this change is that there are some scenarios where `500ms` is not enough to update the `currentTime` and some `PLAYBACK_BUFFERING` were being triggered not correctly.

## Changes

- `html5_video.js`:
  - Implement two new options: `disablePlayheadMovingCheck` and `playheadMovingCheckInterval`
  - Prevent exceptions when checking `canPlay` with `undefined` value