### PR TITLE
HTML5 Video - Fix logic to disable playhead moving check

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -374,7 +374,7 @@ export default class HTML5Video extends Playback {
   }
 
   _startPlayheadMovingChecks() {
-    if (this._playheadMovingTimer !== null && !this._playheadMovingCheckEnabled)
+    if (this._playheadMovingTimer !== null || !this._playheadMovingCheckEnabled)
       return
 
     this._playheadMovingTimeOnCheck = null


### PR DESCRIPTION
This MR is a complement of the https://github.com/clappr/clappr-core/pull/109.
It just fixes the logic to disable the playhead moving check.