### PR TITLE
Add Picture in Picture events in HTML5Video

### DIFF
--- a/src/base/events/events.js
+++ b/src/base/events/events.js
@@ -333,14 +333,14 @@ Events.PLAYER_SUBTITLE_AVAILABLE = 'subtitleavailable'
 // Playback Events
 /** Fired when picture-in-picture mode is entered
  *
- * @event PLAYBACK_ENTER_PIP
+ * @event PLAYBACK_PIP_ENTER
  */
-Events.PLAYBACK_ENTER_PIP = 'playback:enter:picture-in-picture'
+Events.PLAYBACK_PIP_ENTER = 'playback:picture-in-picture:enter'
 /** Fired when picture-in-picture mode is exited
  *
- * @event PLAYBACK_EXIT_PIP
+ * @event PLAYBACK_PIP_EXIT
  */
-Events.PLAYBACK_EXIT_PIP = 'playback:exit:picture-in-picture'
+Events.PLAYBACK_PIP_EXIT = 'playback:picture-in-picture:exit'
 /**
  * Fired when the playback is downloading the media
  *
@@ -775,14 +775,14 @@ Events.CONTAINER_MOUSE_DOWN = 'container:mousedown'
 
 /**
  *  Fired when the container enters on Picture-in-Picture mode
- * @event CONTAINER_ENTER_PIP
+ * @event CONTAINER_PIP_ENTER
  */
-Events.CONTAINER_ENTER_PIP = 'container:enter:picture-in-picture'
+Events.CONTAINER_PIP_ENTER = 'container:picture-in-picture:enter'
 /**
  * Fired when the container exits from Picture-in-Picture mode
- * @event CONTAINER_EXIT_PIP
+ * @event CONTAINER_PIP_EXIT
  */
-Events.CONTAINER_EXIT_PIP = 'container:exit:picture-in-picture'
+Events.CONTAINER_PIP_EXIT = 'container:picture-in-picture:exit'
 
 /**
  * Fired when the container seeks the video

--- a/src/base/events/events.js
+++ b/src/base/events/events.js
@@ -331,6 +331,16 @@ Events.PLAYER_VOLUMEUPDATE = 'volumeupdate'
 Events.PLAYER_SUBTITLE_AVAILABLE = 'subtitleavailable'
 
 // Playback Events
+/** Fired when picture-in-picture mode is entered
+ *
+ * @event PLAYBACK_ENTER_PIP
+ */
+Events.PLAYBACK_ENTER_PIP = 'playback:enter:picture-in-picture'
+/** Fired when picture-in-picture mode is exited
+ *
+ * @event PLAYBACK_EXIT_PIP
+ */
+Events.PLAYBACK_EXIT_PIP = 'playback:exit:picture-in-picture'
 /**
  * Fired when the playback is downloading the media
  *
@@ -762,6 +772,17 @@ Events.CONTAINER_MOUSE_ENTER = 'container:mouseenter'
 Events.CONTAINER_MOUSE_LEAVE = 'container:mouseleave'
 Events.CONTAINER_MOUSE_UP = 'container:mouseup'
 Events.CONTAINER_MOUSE_DOWN = 'container:mousedown'
+
+/**
+ *  Fired when the container enters on Picture-in-Picture mode
+ * @event CONTAINER_ENTER_PIP
+ */
+Events.CONTAINER_ENTER_PIP = 'container:enter:picture-in-picture'
+/**
+ * Fired when the container exits from Picture-in-Picture mode
+ * @event CONTAINER_EXIT_PIP
+ */
+Events.CONTAINER_EXIT_PIP = 'container:exit:picture-in-picture'
 
 /**
  * Fired when the container seeks the video

--- a/src/base/playback/playback.js
+++ b/src/base/playback/playback.js
@@ -23,10 +23,10 @@ import $ from 'clappr-zepto'
  */
 export default class Playback extends UIObject {
   /**
-  * Determine if the playback does not contain video/has video but video should be ignored.
-  * @property isAudioOnly
-  * @type Boolean
-  */
+   * Determine if the playback does not contain video/has video but video should be ignored.
+   * @property isAudioOnly
+   * @type Boolean
+   */
   get isAudioOnly() {
     return false
   }
@@ -121,6 +121,18 @@ export default class Playback extends UIObject {
    * @method stop
    */
   stop() {}
+
+  /**
+   * enter in picture in picture mode
+   * @method enterPiP
+   */
+  enterPiP() {}
+
+  /**
+   * exit from picture in picture mode
+   * @method exitPiP
+   */
+  exitPiP() {}
 
   /**
    * seeks the playback to a given `time` in seconds

--- a/src/base/playback/playback.js
+++ b/src/base/playback/playback.js
@@ -85,6 +85,15 @@ export default class Playback extends UIObject {
   }
 
   /**
+   * checks if picture in picture mode is active.
+   * @property isPiPActive
+   * @type {Boolean} `true` if the current playback is in picture in picture mode, otherwise `false`
+   */
+  get isPiPActive() { 
+    return false 
+  }
+
+  /**
    * @method constructor
    * @param {Object} options the options object
    * @param {Strings} i18n the internationalization component

--- a/src/base/playback/playback.js
+++ b/src/base/playback/playback.js
@@ -23,10 +23,10 @@ import $ from 'clappr-zepto'
  */
 export default class Playback extends UIObject {
   /**
-   * Determine if the playback does not contain video/has video but video should be ignored.
-   * @property isAudioOnly
-   * @type Boolean
-   */
+  * Determine if the playback does not contain video/has video but video should be ignored.
+  * @property isAudioOnly
+  * @type Boolean
+  */
   get isAudioOnly() {
     return false
   }

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -174,6 +174,8 @@ export default class Container extends UIObject {
    * | play |
    * | pause |
    * | error |
+   * | enter_pip |
+   * | exit_pip |
    *
    * ps: the events usually translate from PLABACK_x to CONTAINER_x, you can check all the events at `Event` class.
    *
@@ -204,6 +206,8 @@ export default class Container extends UIObject {
     this.listenTo(this.playback, Events.PLAYBACK_SUBTITLE_CHANGED, this.subtitleChanged)
     this.listenTo(this.playback, Events.PLAYBACK_AUDIO_AVAILABLE, this.audioAvailable)
     this.listenTo(this.playback, Events.PLAYBACK_AUDIO_CHANGED, this.audioChanged)
+    this.listenTo(this.playback, Events.PLAYBACK_ENTER_PIP, this.enterPiP)
+    this.listenTo(this.playback, Events.PLAYBACK_EXIT_PIP, this.exitPiP)
   }
 
   subtitleAvailable() {
@@ -451,6 +455,14 @@ export default class Container extends UIObject {
 
   bufferfull() {
     this.trigger(Events.CONTAINER_STATE_BUFFERFULL, this.name)
+  }
+
+  enterPiP() {
+    this.trigger(Events.CONTAINER_ENTER_PIP, this.name)
+  }
+
+  exitPiP() {
+    this.trigger(Events.CONTAINER_EXIT_PIP, this.name)
   }
 
   /**

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -182,8 +182,8 @@ export default class Container extends UIObject {
    * | play |
    * | pause |
    * | error |
-   * | enter_pip |
-   * | exit_pip |
+   * | pip_enter |
+   * | pip_exit |
    *
    * ps: the events usually translate from PLABACK_x to CONTAINER_x, you can check all the events at `Event` class.
    *
@@ -214,8 +214,8 @@ export default class Container extends UIObject {
     this.listenTo(this.playback, Events.PLAYBACK_SUBTITLE_CHANGED, this.subtitleChanged)
     this.listenTo(this.playback, Events.PLAYBACK_AUDIO_AVAILABLE, this.audioAvailable)
     this.listenTo(this.playback, Events.PLAYBACK_AUDIO_CHANGED, this.audioChanged)
-    this.listenTo(this.playback, Events.PLAYBACK_ENTER_PIP, this.onEnterPiP)
-    this.listenTo(this.playback, Events.PLAYBACK_EXIT_PIP, this.onExitPiP)
+    this.listenTo(this.playback, Events.PLAYBACK_PIP_ENTER, this.onEnterPiP)
+    this.listenTo(this.playback, Events.PLAYBACK_PIP_EXIT, this.onExitPiP)
   }
 
   subtitleAvailable() {
@@ -466,11 +466,11 @@ export default class Container extends UIObject {
   }
 
   onEnterPiP() {
-    this.trigger(Events.CONTAINER_ENTER_PIP, this.name)
+    this.trigger(Events.CONTAINER_PIP_ENTER, this.name)
   }
 
   onExitPiP() {
-    this.trigger(Events.CONTAINER_EXIT_PIP, this.name)
+    this.trigger(Events.CONTAINER_PIP_EXIT, this.name)
   }
 
   /**

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -206,8 +206,8 @@ export default class Container extends UIObject {
     this.listenTo(this.playback, Events.PLAYBACK_SUBTITLE_CHANGED, this.subtitleChanged)
     this.listenTo(this.playback, Events.PLAYBACK_AUDIO_AVAILABLE, this.audioAvailable)
     this.listenTo(this.playback, Events.PLAYBACK_AUDIO_CHANGED, this.audioChanged)
-    this.listenTo(this.playback, Events.PLAYBACK_ENTER_PIP, this.enterPiP)
-    this.listenTo(this.playback, Events.PLAYBACK_EXIT_PIP, this.exitPiP)
+    this.listenTo(this.playback, Events.PLAYBACK_ENTER_PIP, this.onEnterPiP)
+    this.listenTo(this.playback, Events.PLAYBACK_EXIT_PIP, this.onExitPiP)
   }
 
   subtitleAvailable() {
@@ -457,11 +457,11 @@ export default class Container extends UIObject {
     this.trigger(Events.CONTAINER_STATE_BUFFERFULL, this.name)
   }
 
-  enterPiP() {
+  onEnterPiP() {
     this.trigger(Events.CONTAINER_ENTER_PIP, this.name)
   }
 
-  exitPiP() {
+  onExitPiP() {
     this.trigger(Events.CONTAINER_EXIT_PIP, this.name)
   }
 
@@ -513,6 +513,14 @@ export default class Container extends UIObject {
   mouseDown() {
     if (!this.options.chromeless || this.options.allowUserInteraction)
       this.trigger(Events.CONTAINER_MOUSE_DOWN)
+  }
+
+  enterPiP() {
+    this.playback.enterPiP()
+  }
+
+  exitPiP() {
+    this.playback.exitPiP()
   }
 
   settingsUpdate() {

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -128,6 +128,14 @@ export default class Container extends UIObject {
   }
 
   /**
+  * returns the picture-in-picture state.
+  * @type {Boolean}
+  */
+  get isPiPActive() {
+    return this.playback.isPiPActive
+  }
+
+  /**
    * it builds a container
    * @method constructor
    * @param {Object} options the options object

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -73,8 +73,8 @@ export default class HTML5Video extends Playback {
       'stalled': '_handleBufferingEvents',
       'timeupdate': '_onTimeUpdate',
       'waiting': '_onWaiting',
-      'enterpictureinpicture': '_onEnterPIP',
-      'leavepictureinpicture': '_onExitPIP'
+      'enterpictureinpicture': '_onEnterPiP',
+      'leavepictureinpicture': '_onExitPiP'
     }
   }
 
@@ -459,31 +459,31 @@ export default class HTML5Video extends Playback {
     this.trigger(Events.PLAYBACK_ENDED, this.name)
   }
 
-  _onEnterPIP() {
+  _onEnterPiP() {
     this.trigger(Events.PLAYBACK_ENTER_PIP, this.name)
   }
 
-  _onExitPIP() {
+  _onExitPiP() {
     this.trigger(Events.PLAYBACK_EXIT_PIP, this.name)
   }
 
-  togglePIP() {
+  togglePiP() {
     document.pictureInPictureElement ? this.exitPIP() : this.enterPIP()
   }
 
-  enterPIP() {
+  enterPiP() {
     this.el.requestPictureInPicture().then(() => {
-      Log.info('enter PIP success')
+      Log.info(this.name, 'enter PIP success')
     }).catch(e => {
-      Log.warn('enter PIP failed', e)
+      Log.warn(this.name, 'enter PIP failed', e)
     })
   }
 
-  exitPIP() {
+  exitPiP() {
     document.exitPictureInPicture().then(() => {
-      Log.info('exit PIP success')
+      Log.info(this.name, 'exit PIP success')
     }).catch(e => {
-      Log.warn('exit PIP failed', e)
+      Log.warn(this.name, 'exit PIP failed', e)
     })
   }
 

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -126,7 +126,6 @@ export default class HTML5Video extends Playback {
     this._playheadMoving = false
     this._playheadMovingTimer = null
     this._stopped = false
-    this.pipEventHandler = false
     this._ccTrackId = -1
     this._playheadMovingCheckEnabled = !this.options.disablePlayheadMovingCheck
     this._setupSrc(this.options.src)
@@ -461,15 +460,11 @@ export default class HTML5Video extends Playback {
   }
 
   _onEnterPIP() {
-    if (this.pipEventHandler) return
     this.trigger(Events.PLAYBACK_ENTER_PIP, this.name)
-    this.pipEventHandler = true
   }
 
   _onExitPIP() {
-    if (!this.pipEventHandler) return
     this.trigger(Events.PLAYBACK_EXIT_PIP, this.name)
-    this.pipEventHandler = false
   }
 
   togglePIP() {
@@ -478,7 +473,7 @@ export default class HTML5Video extends Playback {
 
   enterPIP() {
     this.el.requestPictureInPicture().then(() => {
-      this._onEnterPIP()
+      Log.info('enter PIP success')
     }).catch(e => {
       Log.warn('enter PIP failed', e)
     })
@@ -486,7 +481,7 @@ export default class HTML5Video extends Playback {
 
   exitPIP() {
     document.exitPictureInPicture().then(() => {
-      this._onExitPIP()
+      Log.info('exit PIP success')
     }).catch(e => {
       Log.warn('exit PIP failed', e)
     })
@@ -730,15 +725,6 @@ export default class HTML5Video extends Playback {
     }
 
     this._ready()
-
-    // Note: Example of Picture-in-Picture
-    // const pipButton = document.createElement('button', { class: 'pip-button' })
-    // document.body.appendChild(pipButton)
-    // pipButton.innerHTML = 'Picture-in-Picture'
-    // pipButton.addEventListener('click', () => {
-    //   this.togglePIP()
-    // })
-
     const style = Styler.getStyleFor(HTML5VideoStyle.toString(), { baseUrl: this.options.baseUrl })
     this.$el.append(style[0])
     return this

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -468,7 +468,7 @@ export default class HTML5Video extends Playback {
   }
 
   togglePiP() {
-    document.pictureInPictureElement ? this.exitPIP() : this.enterPIP()
+    document.pictureInPictureElement ? this.exitPiP() : this.enterPiP()
   }
 
   enterPiP() {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -73,8 +73,8 @@ export default class HTML5Video extends Playback {
       'stalled': '_handleBufferingEvents',
       'timeupdate': '_onTimeUpdate',
       'waiting': '_onWaiting',
-      'enterpictureinpicture': '_onEnterPiP',
-      'leavepictureinpicture': '_onExitPiP'
+      'enterpictureinpicture': '_onEnterPIP',
+      'leavepictureinpicture': '_onExitPIP'
     }
   }
 
@@ -126,6 +126,7 @@ export default class HTML5Video extends Playback {
     this._playheadMoving = false
     this._playheadMovingTimer = null
     this._stopped = false
+    this.pipEventHandler = false
     this._ccTrackId = -1
     this._playheadMovingCheckEnabled = !this.options.disablePlayheadMovingCheck
     this._setupSrc(this.options.src)
@@ -460,11 +461,19 @@ export default class HTML5Video extends Playback {
   }
 
   _onEnterPIP() {
+    if (this.pipEventHandler) return
     this.trigger(Events.PLAYBACK_ENTER_PIP, this.name)
+    this.pipEventHandler = true
   }
 
   _onExitPIP() {
+    if (!this.pipEventHandler) return
     this.trigger(Events.PLAYBACK_EXIT_PIP, this.name)
+    this.pipEventHandler = false
+  }
+
+  togglePIP() {
+    document.pictureInPictureElement ? this.exitPIP() : this.enterPIP()
   }
 
   enterPIP() {
@@ -721,6 +730,15 @@ export default class HTML5Video extends Playback {
     }
 
     this._ready()
+
+    // Note: Example of Picture-in-Picture
+    // const pipButton = document.createElement('button', { class: 'pip-button' })
+    // document.body.appendChild(pipButton)
+    // pipButton.innerHTML = 'Picture-in-Picture'
+    // pipButton.addEventListener('click', () => {
+    //   this.togglePIP()
+    // })
+
     const style = Styler.getStyleFor(HTML5VideoStyle.toString(), { baseUrl: this.options.baseUrl })
     this.$el.append(style[0])
     return this

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -464,11 +464,11 @@ export default class HTML5Video extends Playback {
   }
 
   _onEnterPiP() {
-    this.trigger(Events.PLAYBACK_ENTER_PIP, this.name)
+    this.trigger(Events.PLAYBACK_PIP_ENTER, this.name)
   }
 
   _onExitPiP() {
-    this.trigger(Events.PLAYBACK_EXIT_PIP, this.name)
+    this.trigger(Events.PLAYBACK_PIP_EXIT, this.name)
   }
 
   togglePiP() {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -471,10 +471,6 @@ export default class HTML5Video extends Playback {
     this.trigger(Events.PLAYBACK_PIP_EXIT, this.name)
   }
 
-  togglePiP() {
-    document.pictureInPictureElement ? this.exitPiP() : this.enterPiP()
-  }
-
   enterPiP() {
     this.el.requestPictureInPicture().then(() => {
       Log.info(this.name, 'enter PIP success')

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -98,6 +98,10 @@ export default class HTML5Video extends Playback {
     return this._isBuffering
   }
 
+  get isPiPActive() {
+    return this.el === document.pictureInPictureElement
+  }
+
   get isLive() {
     return this.getPlaybackType() === Playback.LIVE
   }
@@ -529,6 +533,7 @@ export default class HTML5Video extends Playback {
     this._destroyed = true
     this.handleTextTrackChange && this.el.textTracks.removeEventListener('change', this.handleTextTrackChange)
     this.$el.off('contextmenu')
+    this.isPiPActive && this.exitPiP()
     super.destroy()
     this.el.removeAttribute('src')
     this.el.load() // load with no src to stop loading of the previous source and avoid leaks

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -72,7 +72,9 @@ export default class HTML5Video extends Playback {
       'seeked': '_onSeeked',
       'stalled': '_handleBufferingEvents',
       'timeupdate': '_onTimeUpdate',
-      'waiting': '_onWaiting'
+      'waiting': '_onWaiting',
+      'enterpictureinpicture': '_onEnterPiP',
+      'leavepictureinpicture': '_onExitPiP'
     }
   }
 
@@ -455,6 +457,30 @@ export default class HTML5Video extends Playback {
   _onEnded() {
     this._handleBufferingEvents()
     this.trigger(Events.PLAYBACK_ENDED, this.name)
+  }
+
+  _onEnterPIP() {
+    this.trigger(Events.PLAYBACK_ENTER_PIP, this.name)
+  }
+
+  _onExitPIP() {
+    this.trigger(Events.PLAYBACK_EXIT_PIP, this.name)
+  }
+
+  enterPIP() {
+    this.el.requestPictureInPicture().then(() => {
+      this._onEnterPIP()
+    }).catch(e => {
+      Log.warn('enter PIP failed', e)
+    })
+  }
+
+  exitPIP() {
+    document.exitPictureInPicture().then(() => {
+      this._onExitPIP()
+    }).catch(e => {
+      Log.warn('exit PIP failed', e)
+    })
   }
 
   // The playback should be classed as buffering if the following are true:


### PR DESCRIPTION
## Summary

This PR implements the picture in picture feature that can be useful for PiP Plugins

## Changes

- `html5_video.js`:
  - add handlers to picture-in-picture 
- `events.js`: 
  -  add events to handle EnterPIP and ExitPIP
- `container.js`: 
  - bind pip playback events to container events
- `playback.js`: 
  - add methods to pip mode


## How to test

1. There's an example in code comments that uses a simple button

## Images

### After this PR

<img width="400" alt="pip" src="https://github.com/clappr/clappr-core/assets/71555436/b448dea7-3bbd-4ac3-a830-d5b55630e4c7">


