### PR TITLE
Handle PiP Binge-Watching in HTML5Video

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -529,7 +529,6 @@ export default class HTML5Video extends Playback {
     this._destroyed = true
     this.handleTextTrackChange && this.el.textTracks.removeEventListener('change', this.handleTextTrackChange)
     this.$el.off('contextmenu')
-    this.isPiPActive && this.exitPiP()
     super.destroy()
     this.el.removeAttribute('src')
     this.el.load() // load with no src to stop loading of the previous source and avoid leaks


### PR DESCRIPTION
## Summary

This PR updates HTML5 Picture-In-Picture to handle binge-watching

## Changes

- `html5_video.js`: removing exitPiP from destroy 


