### PR TITLE
Playback – Setup latency default value as null

### DIFF
--- a/src/base/playback/playback.js
+++ b/src/base/playback/playback.js
@@ -71,7 +71,7 @@ export default class Playback extends UIObject {
    * @type {Number}
    */
   get latency() {
-    return 0
+    return null
   }
 
   /**


### PR DESCRIPTION
This PR refactors the Playback's `latency` getter default value.

When the value isn't implemented in a Playback, it should return an invalid value like `null`.